### PR TITLE
yeelink.mirror.bm1/yeelink.light.panel3/lumi.airer.acn01/lumi.sensor_gas.mcn02

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -273,6 +273,10 @@ DEVICE_CUSTOMIZES = {
         'interval_seconds': 15,
         'motion_timeout': 60,
     },
+    'lumi.sensor_gas.mcn02': {
+        'chunk_properties': 1,
+        'exclude_miot_services': 'gas_sensor_control',
+    },
     'lumi.sensor_motion.*': {
         'interval_seconds': 15,
         'motion_timeout': 60,

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -257,7 +257,6 @@ DEVICE_CUSTOMIZES = {
             },
         ],
         'select_properties': 'dry_mode',
-        'exclude_miot_services': 'dryer',
     },
     'lumi.ctrl_neutral1.*': {
         'cloud_delay_update': 10,

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -237,6 +237,28 @@ DEVICE_CUSTOMIZES = {
         'device_class': 'energy',
         'unit_of_measurement': 'kWh',
     },
+    'lumi.airer.acn01': {
+        'extend_miot_specs': [
+            {
+                'iid': 2,
+                'properties': [
+                    {
+                        'iid': 101,
+                        'type': 'urn:miot-spec-v2:property:dry_mode',
+                        'format': 'uint8',
+                        'access': ['read', 'write'],
+                        'value-list': [
+                            {'value': 0, 'description': 'off'},
+                            {'value': 1, 'description': 'dry'},
+                            {'value': 2, 'description': 'winddry'},
+                        ],
+                    },
+                ],
+            },
+        ],
+        'select_properties': 'dry_mode',
+        'exclude_miot_services': 'dryer',
+    },
     'lumi.ctrl_neutral1.*': {
         'cloud_delay_update': 10,
     },

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -164,6 +164,19 @@ MIIO_TO_MIOT_SPECS = {
                 'setter': 'control_device',
                 'set_template': '{{ ["start_hotdry",90] if value else ["stop_hotdry",0] }}',
             },
+            'prop.2.101': {
+                'prop': 'dry_status','dict': {
+                  'off': 0,
+                  'hotdry': 1,
+                  'winddry': 2,
+                },
+                'setter': 'control_device',
+                'set_template': '{{ '
+                  '["stop_winddry",0] if "winddry" in props.dry_status and value==0 else '
+                  '["stop_hotdry",0] if "hotdry" in props.dry_status and value==0 else '
+                  '["start_hotdry",90] if value==1 else '
+                  '["start_winddry",90]}}',
+            },
             'prop.2.5': {'prop': 'dry_remaining_time'},
             'prop.3.1': {'prop': 'light', 'setter': 'toggle_light', 'format': 'onoff'},
         },

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -603,10 +603,8 @@ MIIO_TO_MIOT_SPECS = {
         },
     },
     'yeelink.light.ceiling6': {
+        'extend_model': 'yeelink.mirror.bm1',
         'miio_specs': {
-            'prop.2.1': {'prop': 'power', 'setter': True, 'format': 'onoff'},
-            'prop.2.2': {'prop': 'bright', 'setter': True},
-            'prop.2.3': {'prop': 'ct', 'setter': 'set_ct_abx', 'set_template': "{{ [value,'smooth',500] }}"},
             'prop.2.4': {
                 'prop': 'nl_br',
                 'setter': 'set_ps',
@@ -668,6 +666,7 @@ MIIO_TO_MIOT_SPECS = {
         },
     },
     'yeelink.light.panel1': 'yeelink.light.ceiling2',
+    'yeelink.light.panel3': 'yeelink.light.ceiling2',
     'yeelink.light.strip1': 'yeelink.light.color1',
     'yeelink.light.strip2': {
         'miio_specs': {
@@ -697,6 +696,13 @@ MIIO_TO_MIOT_SPECS = {
                 'template': "{{ value in ['swing'] }}",
                 'set_template': "{{ ['swing' if value else 'stop'] }}",
             },
+        },
+    },
+    'yeelink.mirror.bm1': {
+        'miio_specs': {
+            'prop.2.1': {'prop': 'power', 'setter': True, 'format': 'onoff'},
+            'prop.2.2': {'prop': 'bright', 'setter': True},
+            'prop.2.3': {'prop': 'ct', 'setter': 'set_ct_abx', 'set_template': "{{ [value,'smooth',500] }}"},
         },
     },
     'yeelink.ven_fan.vf3': {


### PR DESCRIPTION
- 🎉 New miio2miot devices:
  - [yeelink.light.panel3](https://home.miot-spec.com/s/yeelink.light.panel3)
  - [yeelink.mirror.bm1](https://home.miot-spec.com/s/yeelink.mirror.bm1)
- add `dry_mode` for [lumi.airer.acn01](https://home.miot-spec.com/s/lumi.airer.acn01)
- fix for [lumi.sensor_gas.mcn02](https://home.miot-spec.com/s/lumi.sensor_gas.mcn02)
