### PR TITLE
adding another "pause sweep" option

### DIFF
--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -85,7 +85,7 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
         self._prop_status = miot_service.get_property('status')
         self._prop_mode = miot_service.get_property('fan_level', 'speed_level', 'mode')
         self._act_start = miot_service.get_action('start_sweep')
-        self._act_pause = miot_service.get_action('pause_sweeping','pause')
+        self._act_pause = miot_service.get_action('pause_sweeping', 'pause')
         self._act_stop = miot_service.get_action('stop_sweeping')
         self._act_locate = miot_service.get_action('position')
         self._prop_battery = miot_service.get_property('battery_level')

--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -85,7 +85,7 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
         self._prop_status = miot_service.get_property('status')
         self._prop_mode = miot_service.get_property('fan_level', 'speed_level', 'mode')
         self._act_start = miot_service.get_action('start_sweep')
-        self._act_pause = miot_service.get_action('pause_sweeping')
+        self._act_pause = miot_service.get_action('pause_sweeping','pause')
         self._act_stop = miot_service.get_action('stop_sweeping')
         self._act_locate = miot_service.get_action('position')
         self._prop_battery = miot_service.get_property('battery_level')

--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -87,14 +87,14 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
         self._act_start = miot_service.get_action('start_sweep')
         self._act_pause = miot_service.get_action('pause_sweeping', 'pause')
         self._act_stop = miot_service.get_action('stop_sweeping')
-        self._act_locate = miot_service.get_action('position')
+        self._act_locate = miot_service.get_action('find_device', 'position')
         self._prop_battery = miot_service.get_property('battery_level')
         self._srv_battery = miot_service.spec.get_service('battery')
         if self._srv_battery:
             self._prop_battery = self._srv_battery.get_property('battery_level')
         self._srv_audio = miot_service.spec.get_service('audio', 'voice')
         if self._srv_audio and not self._act_locate:
-            self._act_locate = self._srv_battery.get_property('position', 'find_device')
+            self._act_locate = self._srv_audio.get_action('find_device', 'position')
         self._act_charge = None
         for srv in [*miot_service.spec.get_services('battery', 'go_charging'), miot_service]:
             act = srv.get_action('start_charge', 'start_charging')


### PR DESCRIPTION
[viomi.vacuum.v18](https://home.miot-spec.com/s/viomi.vacuum.v18) uses "pause" as pause sweeping action.

I also managed to add find vacuum option but don't know how to add it in the code.

I changed line 97 to
`            self._act_locate = self._srv_audio.get_action('position', 'find_device')`

but I guess it would break some other devices