### PR TITLE
Dreame mc1808: Fix incorrect spec property set to notify only when it supports read

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -208,6 +208,23 @@ DEVICE_CUSTOMIZES = {
     'dreame.vacuum.*': {
         'exclude_miot_services': 'consumable,annoy,remote,time',
     },
+    'dreame.vacuum.mc1808': {
+        'extend_miot_specs': [
+            {
+                'iid': 18,
+                'properties': [
+                    {
+                        'iid': 9,
+                        'type': 'urn:dreame-spec:property:water-box:0000000A:dreame-mc1808:1',
+                        'description': 'water-box',
+                        'format': 'int32',
+                        'access': ['read', 'notify'],
+                        'value-range': [0, 10, 1],
+                    },
+                ],
+            },
+        ],
+    },
     'fawad.airrtc.*': {
         'exclude_miot_services': 'thermostat_vrf',
     },


### PR DESCRIPTION
This property determines the state of the water box (ie mopping vs not mopping), but the [miot spec](https://home.miot-spec.com/spec/dreame.vacuum.mc1808) is incorrect as the property access is read and notify while the spec just has notify