### PR TITLE
🇺🇸  Translate ijai.vacuum.v3 fan speed to English

### DIFF
--- a/custom_components/xiaomi_miot/core/translation_languages.py
+++ b/custom_components/xiaomi_miot/core/translation_languages.py
@@ -1,6 +1,5 @@
 # https://iot.mi.com/new/doc/tools-and-resources/design/spec/description
 TRANSLATION_LANGUAGES = {
-
     'zh': {
         'off': '关闭',
         'idle': '空闲',
@@ -248,4 +247,14 @@ TRANSLATION_LANGUAGES = {
         },
     },
 
+    'en': {
+        # Vacuum reports its fan speeds in ZH. We need to have an English
+        # translation for them.
+        'sweep.suction_state': {
+            '关': 'Silent',
+            '节能': 'Standart',
+            '标准': 'Medium',
+            '强劲': 'Turbo',
+        },
+    },
 }


### PR DESCRIPTION
ijai.vacuum.v3 reports its fan speed list in ZH.
For English translation we would like to have it in English :)

Before:
<img width="414" alt="Screenshot 2022-06-08 at 04 16 00" src="https://user-images.githubusercontent.com/35844154/172510470-a0707ad3-d92b-458f-ab8d-4e9d2458b439.png">

After:
<img width="445" alt="Screenshot 2022-06-08 at 04 13 28" src="https://user-images.githubusercontent.com/35844154/172510479-d1fbb1e9-fce7-4619-a07f-d25e8631261b.png">

To enable it add the next lines to configuration.yaml:
```
xiaomi_miot:
  language: en
```

