### PR TITLE
Fix number entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 __pycache__/
 

--- a/custom_components/xiaomi_miot/number.py
+++ b/custom_components/xiaomi_miot/number.py
@@ -93,12 +93,6 @@ class MiotNumberSubEntity(MiotPropertySubEntity, NumberEntity, RestoreEntity):
         val = self._miot_property.from_dict(self._state_attrs)
         return self.cast_value(val)
 
-    def set_native_value(self, value):
-        """Set new value."""
-        if self._miot_property.is_integer:
-            value = int(value)
-        return self.set_parent_property(value)
-
     @property
     def value(self):
         return self.native_value
@@ -111,6 +105,12 @@ class MiotNumberSubEntity(MiotPropertySubEntity, NumberEntity, RestoreEntity):
         except (TypeError, ValueError):
             val = default
         return val
+
+    def set_native_value(self, value):
+        """Set new value."""
+        if self._miot_property.is_integer:
+            value = int(value)
+        return self.set_parent_property(value)
 
     def set_value(self, value):
         """Set new value."""

--- a/custom_components/xiaomi_miot/number.py
+++ b/custom_components/xiaomi_miot/number.py
@@ -91,11 +91,16 @@ class MiotNumberSubEntity(MiotPropertySubEntity, NumberEntity, RestoreEntity):
     @property
     def native_value(self):
         val = self._miot_property.from_dict(self._state_attrs)
-        return self.cast_value(val)
+        return val
 
     @property
     def value(self):
-        return self.native_value
+        val = self.cast_value(val)
+        if val is None:
+            return val
+        if hasattr(self, '_convert_to_state_value'):
+            val = self._convert_to_state_value(val, round)
+        return val
 
     def cast_value(self, val, default=None):
         try:


### PR DESCRIPTION
This PR fixes ability to read and write number properties.

It looks like it was broken in version 0.6.10 by this commit https://github.com/al-one/hass-xiaomi-miot/commit/c9edc80a4c3070d0e29cec3e062f8b96f5ec56c8 

Fix tested on towel rack OWS-S1. Value of "Target Temperature" property can be set correctly now instead of unavailability in v0.6.10.