### PR TITLE
fix Day/Night mode for ceiling 22/23

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1610,8 +1610,8 @@ MIIO_TO_MIOT_SPECS = {
             'prop.2.5': {'prop': 'smart_switch'},
         },
     },
-    'yeelink.light.ceiling22': 'yeelink.light.ceiling21',
-    'yeelink.light.ceiling23': 'yeelink.light.ceiling21',
+    'yeelink.light.ceiling22': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling23': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling24': 'yeelink.light.ceiling16',
     'yeelink.light.lamp2': 'yeelink.light.ceiling16',
     'yeelink.light.lamp3': {


### PR DESCRIPTION
Fix an issue related to not being able to change the Day/Night mode of yeelink.light.ceiling22/23.

Day mode should be 1, Night mode should be 2.

But if Night mode is on, when you change the brightness, the brightness level shown in HASS stays the same. But the light actually changes its brightness, and the brightness also changed in Xiaomi Home App. In Day mode, everything works fine, no problem.

I can't find a way to fix this.