### PR TITLE
Added throw option to request_xiaomi_api service

### DIFF
--- a/custom_components/xiaomi_miot/__init__.py
+++ b/custom_components/xiaomi_miot/__init__.py
@@ -164,6 +164,7 @@ SERVICE_TO_METHOD_BASE = {
                 vol.Optional('method', default='POST'): cv.string,
                 vol.Optional('crypt', default=True): cv.boolean,
                 vol.Optional('sid', default=None): vol.Any(cv.string, None),
+                vol.Optional('throw', default=False): cv.boolean,
             },
         ),
     },
@@ -2110,12 +2111,13 @@ class MiotEntity(MiioEntity):
             'data': dat,
             'result': result,
         })
-        persistent_notification.async_create(
-            self.hass,
-            f'{result}',
-            f'Xiaomi Api: {api}',
-            f'{DOMAIN}-debug',
-        )
+        if kwargs.get('throw'):
+            persistent_notification.async_create(
+                self.hass,
+                f'{result}',
+                f'Xiaomi Api: {api}',
+                f'{DOMAIN}-debug',
+            )
         _LOGGER.debug('Xiaomi Api %s: %s', api, result)
         return result
 

--- a/custom_components/xiaomi_miot/services.yaml
+++ b/custom_components/xiaomi_miot/services.yaml
@@ -352,3 +352,9 @@ request_xiaomi_api:
               value: micoapi
             - label: i.mi.com
               value: i.mi.com
+    throw:
+      description: Throw result.
+      default: false
+      example: false
+      selector:
+        boolean:

--- a/custom_components/xiaomi_miot/services.yaml
+++ b/custom_components/xiaomi_miot/services.yaml
@@ -354,7 +354,7 @@ request_xiaomi_api:
               value: i.mi.com
     throw:
       description: Throw result.
-      default: false
-      example: false
+      default: true
+      example: true
       selector:
         boolean:


### PR DESCRIPTION
I've been using request_xiaomi_api service, and there were no method to disable the notification.
Implemented this feature by adding "throw" option similar to the other service calls.
