### PR TITLE
Minor 'el' translation additions

### DIFF
--- a/custom_components/xiaomi_miot/core/translation_languages.py
+++ b/custom_components/xiaomi_miot/core/translation_languages.py
@@ -500,6 +500,12 @@ TRANSLATION_LANGUAGES = {
             'turbo': 'Τούρμπο',
         },
 
+        'sweep.water_state': {
+            '低': 'Χαμηλή',
+            '中': 'Μεσαία',
+            '高': 'Υψηλή',
+        },
+
         'television': {
             'input control': 'Πηγή εισόδου',
             'tv input control': 'Πηγή εισόδου τηλεόρασης',


### PR DESCRIPTION
The 'fan' translations were omitted due to the HomeKit integration. Although, the water_state was added here.