### PR TITLE
Fix Airer.dryer switch for lumi.airer.acn01 in LAN mode

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -571,9 +571,13 @@ MIIO_TO_MIOT_SPECS = {
             }, 'default': 3},
             'prop.2.4': {
                 'prop': 'dry_status',
-                'format': 'onoff',
+                'format': 'bool',
+                'template': '{{ False if "off" in props.dry_status else True}}',
                 'setter': 'control_device',
-                'set_template': '{{ ["start_hotdry",90] if value else ["stop_hotdry",0] }}',
+                'set_template': '{{ '
+                                '["start_hotdry",90] if value else '
+                                '["stop_hotdry",0] if "hotdry" in props.dry_status else '
+                                '["stop_winddry",0] }}',
             },
             'prop.2.101': {
                 'prop': 'dry_status',

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -571,8 +571,7 @@ MIIO_TO_MIOT_SPECS = {
             }, 'default': 3},
             'prop.2.4': {
                 'prop': 'dry_status',
-                'format': 'bool',
-                'template': '{{ False if "off" in props.dry_status else True}}',
+                'template': '{{ value != "off" }}',
                 'setter': 'control_device',
                 'set_template': '{{ '
                                 '["start_hotdry",90] if value else '


### PR DESCRIPTION
Hi @al-one!

This fix changes the behavior of the switch "Airer Dryer".
Without it, it doesn't work properly. After the switch state is set manually to "on", the next time the status is updated, its state switches to "off".
I don't really know the architecture of your component, so I ask you to use this code as a concept and fix this issue.

Thanks.