### PR TITLE
feat: add mmgg.pet_waterer.s1 properties to device customizes

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -654,6 +654,12 @@ DEVICE_CUSTOMIZES = {
         'sensor_properties': 'remain_clean_time,fault,filter_left_time,no_water_time',
         'select_properties': 'mode',
     },
+    'mmgg.pet_waterer.s1': {
+        'binary_sensor_properties': 'no_water_flag,pump_block_flag,lid_up_flag',
+        'button_actions': 'reset_filter_life,reset_clean_time',
+        'sensor_properties': 'remain_clean_time,fault,filter_left_time,no_water_time',
+        'select_properties': 'mode',
+    },
     'msj.f_washer.m2': {
         'chunk_properties': 1,
         'button_actions': 'start_wash,pause,drain,pause_drain',


### PR DESCRIPTION
Otherwise no sensors (alerts, etc.) are shown.