### PR TITLE
Add favorite-level control for zhimi.airp.cpa4

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1010,6 +1010,9 @@ DEVICE_CUSTOMIZES = {
         'brightness_for_on': 0,
         'brightness_for_off': 2,
     },
+    'zhimi.airp.cpa4': {
+        'number_properties': 'favorite_level',
+    },
     'zhimi.airp.mb4a': {
         'number_properties': 'favorite_speed',
     },


### PR DESCRIPTION
Adds fan speed control for [Air Purifier 4 Compact](https://home.miot-spec.com/s/zhimi.airp.cpa4)