### PR TITLE
fix qdhkl.aircondition.b23  fan_level descriptions #1099

### DIFF
--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1557,6 +1557,27 @@
         }
       ]
     }
+  ],
+
+  "qdhkl.aircondition.b23": [
+    {
+      "iid": 3,
+      "type": "urn:miot-spec-v2:service:fan-control",
+      "properties": [
+        {
+          "iid": 2,
+          "type": "urn:miot-spec-v2:property:fan-level",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "value-list": [
+            {"value": 0, "description": "Auto"},
+            {"value": 1, "description": "High"},
+            {"value": 2, "description": "Medium"},
+            {"value": 4, "description": "Low"}
+          ]
+        }
+      ]
+    }
   ]
 
 }


### PR DESCRIPTION
修复 #1099 的空调风速和miot-specs不一致的问题
屏蔽preset_mode的方法暂时没找到，修改supported_features = 9应该可以解决