### PR TITLE
增加local_delay_update，适配中弘小超人控制器与空调同步延迟问题

### DIFF
--- a/custom_components/xiaomi_miot/__init__.py
+++ b/custom_components/xiaomi_miot/__init__.py
@@ -1853,6 +1853,7 @@ class MiotEntity(MiioEntity):
                 dly = self.custom_config_integer('cloud_delay_update', 6)
             else:
                 results = self.miot_device.send('set_properties', [pms])
+                dly = self.custom_config_integer('local_delay_update', 1)
             ret = MiotResults(results).first
         except (DeviceException, MiCloudException) as exc:
             self.logger.warning('%s: Set miot property %s failed: %s', self.name_model, pms, exc)
@@ -1919,6 +1920,7 @@ class MiotEntity(MiioEntity):
                 if not kwargs.get('force_params'):
                     pms['in'] = action.in_params(params or [])
                 result = self.miot_device.send('action', pms)
+                dly = self.custom_config_integer('local_delay_update', 1)
             eno = dict(result or {}).get('code', eno)
         except (DeviceException, MiCloudException) as exc:
             self.logger.warning('%s: Call miot action %s failed: %s', self.name_model, pms, exc)

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -739,6 +739,7 @@ DEVICE_CUSTOMIZES = {
         'number_properties': 'numleds,pixel_per_step,fade_delay,step_delay,stair_travel_time',
     },
     'qdhkl.aircondition.b23': {
+        'local_delay_update': 8,
         'cloud_delay_update': 8,
         'miot_type': 'urn:miot-spec-v2:device:air-conditioner:0000A004:qdhkl-b23:2',
     },


### PR DESCRIPTION
中弘小超人空调控制器(qdhkl.aircondition.b23)，和空调的通信有延迟，本地模式下如果操作以后马上获取状态，会获取到操作前的状态，空调开关回弹到操作前的状态。
增加一个local_delay_seconds的可配置参数，用于配置本地模式下的读取延迟

经过测试，这个设备加入和云端同样8秒延迟后，本地模式下也能够正常操作设备

#1099 