### PR TITLE
fix: lumi.motion.bmgl01 error log

### DIFF
--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -345,8 +345,6 @@
         {
           "iid": 1,
           "type": "urn:miot-spec-v2:property:illumination",
-          "format": "bool",
-          "access": ["read"],
           "unit": "lx",
           "value-list": [
             {"value": 1, "description": "0"},

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -338,6 +338,25 @@
     }
   ],
 
+  "lumi.motion.bmgl01": [
+    {
+      "iid": 2,
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:illumination",
+          "format": "bool",
+          "access": ["read"],
+          "unit": "lx",
+          "value-list": [
+            {"value": 1, "description": "0"},
+            {"value": 2, "description": "100"}
+          ]
+        }
+      ]
+    }
+  ],
+
   "midea.aircondition.v1": [
     {
       "iid": 2,


### PR DESCRIPTION
report log 'has device class 'illuminance', state class 'None' unit 'None' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'weak' (<class 'str'>)'