### PR TITLE
cgllc.airm.cgd1st: voltage unit fix

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -61,6 +61,15 @@ DEVICE_CUSTOMIZES = {
     'cgllc.airm.cgdn1': {
         'exclude_miot_services': 'mac,settings',
     },
+    'cgllc.airm.cgd1st': {
+        'exclude_miot_services': 'mac,settings',
+    },
+    'cgllc.airm.cgd1st:voltage': {
+        'value_ratio': 0.001,
+        'state_class': 'measurement',
+        'device_class': 'voltage',
+        'unit_of_measurement': 'V',
+    },
     'chuangmi.camera.v6': {
         'use_alarm_playlist': True,
     },

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -61,6 +61,12 @@ DEVICE_CUSTOMIZES = {
     'cgllc.airm.cgdn1': {
         'exclude_miot_services': 'mac,settings',
     },
+    'cgllc.airm.cgdn1:voltage': {
+        'value_ratio': 0.001,
+        'state_class': 'measurement',
+        'device_class': 'voltage',
+        'unit_of_measurement': 'V',
+    },
     'cgllc.airm.cgd1st': {
         'exclude_miot_services': 'mac,settings',
     },


### PR DESCRIPTION
Fix error for cgllc.airm.cgd1st.
Looks like the same error have cgllc.airm.cgdn1. Fix it, but can't test.
Also copy exclude_miot_services from cgllc.airm.cgdn1 to cgd1st.

`Entity sensor.cgllc_cgd1st_9c7d_voltage (<class 'custom_components.xiaomi_miot.sensor.MiotSensorSubEntity'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('voltage') it is using; expected one of ['mV', 'V']; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.`