### PR TITLE
add option "target2current_temp" for aircondition devices

### DIFF
--- a/custom_components/xiaomi_miot/climate.py
+++ b/custom_components/xiaomi_miot/climate.py
@@ -460,7 +460,7 @@ class MiotClimateEntity(MiotToggleEntity, BaseClimateEntity):
 
     @property
     def current_temperature(self):
-        if self.custom_config('report_target_temp_as_current_temp') is True and self.is_on:
+        if self.custom_config('target2current_temp') is True and self.is_on:
             return self.target_temperature
         if ATTR_CURRENT_TEMPERATURE in self._state_attrs:
             return float(self._state_attrs[ATTR_CURRENT_TEMPERATURE] or 0)

--- a/custom_components/xiaomi_miot/climate.py
+++ b/custom_components/xiaomi_miot/climate.py
@@ -460,6 +460,8 @@ class MiotClimateEntity(MiotToggleEntity, BaseClimateEntity):
 
     @property
     def current_temperature(self):
+        if self.custom_config('report_target_temp_as_current_temp') is True and self.is_on:
+            return self.target_temperature
         if ATTR_CURRENT_TEMPERATURE in self._state_attrs:
             return float(self._state_attrs[ATTR_CURRENT_TEMPERATURE] or 0)
         if self._prop_temperature:

--- a/custom_components/xiaomi_miot/config_flow.py
+++ b/custom_components/xiaomi_miot/config_flow.py
@@ -737,7 +737,7 @@ def get_customize_options(hass, options={}, bool2selects=[], entity_id='', model
         })
 
     if domain == 'climate' or re.search(r'aircondition|acpartner|airrtc', model, re.I):
-        bool2selects.extend(['ignore_fan_switch', 'report_target_temp_as_current_temp'])
+        bool2selects.extend(['ignore_fan_switch', 'target2current_temp'])
         options.update({
             'bind_sensor': cv.string,
             'turn_on_hvac': cv.string,

--- a/custom_components/xiaomi_miot/config_flow.py
+++ b/custom_components/xiaomi_miot/config_flow.py
@@ -737,7 +737,7 @@ def get_customize_options(hass, options={}, bool2selects=[], entity_id='', model
         })
 
     if domain == 'climate' or re.search(r'aircondition|acpartner|airrtc', model, re.I):
-        bool2selects.extend(['ignore_fan_switch'])
+        bool2selects.extend(['ignore_fan_switch', 'report_target_temp_as_current_temp'])
         options.update({
             'bind_sensor': cv.string,
             'turn_on_hvac': cv.string,


### PR DESCRIPTION
this new option `"target2current_temp"` enables the following behavior:

- if the air conditioner is on, report `target_temperature` as `current_temperature`.
- if it is off, fallback to either `bind_sensor` or `current_temp_prop`.

this PR supports the following use case:

- expect HomeKit displays the target temperature instead and
- there is no sensor available in the room where the air conditioner works (therefore `bind_sensor` binds to a sensor in another room or the weather report sensor). If you have a sensor in the room, you don't need this option, just use `bind_sensor`.

with this option enabled, HomeKit reports the target temperature when it's on, and reports the sensor's temperature/temperature from the weather report when the air condition is off.