### PR TITLE
fix indoor temperature for 090615.aircondition.ktf

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1,7 +1,7 @@
 DEVICE_CUSTOMIZES = {
 
     '090615.aircondition.ktf': {
-        'miot_type': 'urn:miot-spec-v2:device:air-conditioner:0000A004:090615-ktf:2',
+        'current_temp_property': 'setmode.roomtemp',
     },
     '090615.curtain.wsdml1': {
         'switch_properties': 'on,wake_up_mode',


### PR DESCRIPTION
相关issue: #1249  #1119  

提交 f9a4d7f3d7eda605f1aa0d78f9b89508d565a73d 尝试对 090615.aircondition.ktf 的室温提供支持，但当前温度始终显示为0

如 #1249 所述，090615.aircondition.ktf 无法从 `environment.temperature` 获取，需要从 `setmode.roomtemp` 中获取正确的室温

本提交尝试修复上述问题，本地已初步验证通过。