### PR TITLE
Fix brightness reading in nightlight mode

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1742,7 +1742,29 @@ MIIO_TO_MIOT_SPECS = {
         },
     },
     'yeelink.light.ceiling7': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling8': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling8': {
+        'extend_model': 'yeelink.mirror.bm1',
+        'miio_commands': [
+            {
+                'method': 'get_prop',
+                'params': ['nl_br'],
+                'values': True,
+            },
+        ],
+        'miio_specs': {
+            'prop.2.2': {
+                'prop': 'bright',
+                'setter': True,
+                'template': '{{ value if props.nl_br|int == 0 else props.nl_br|default(value)|int }}',
+            },
+            'prop.2.4': {
+                'prop': 'active_mode',
+                'setter': 'set_ps',
+                'template': '{{ 2 if value|int else 1 }}',
+                'set_template': '{{ ["nightlight","on" if value == 2 else "off"] }}',
+            },
+        },
+    },
     'yeelink.light.ceiling9': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling10': {
         'extend_model': 'yeelink.light.ceiling6',
@@ -1754,9 +1776,9 @@ MIIO_TO_MIOT_SPECS = {
         },
     },
     'yeelink.light.ceiling11': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling12': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling13': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling14': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling12': 'yeelink.light.ceiling8',
+    'yeelink.light.ceiling13': 'yeelink.light.ceiling8',
+    'yeelink.light.ceiling14': 'yeelink.light.ceiling8',
     'yeelink.light.ceiling15': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling16': {
         'extend_model': 'yeelink.light.ceiling2',

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1732,25 +1732,7 @@ MIIO_TO_MIOT_SPECS = {
     },
     'yeelink.light.ceiling6': {
         'extend_model': 'yeelink.mirror.bm1',
-        'miio_specs': {
-            'prop.2.4': {
-                'prop': 'nl_br',
-                'setter': 'set_ps',
-                'template': '{{ 2 if value|int else 1 }}',
-                'set_template': '{{ ["nightlight","on" if value == 2 else "off"] }}',
-            },
-        },
-    },
-    'yeelink.light.ceiling7': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling8': {
-        'extend_model': 'yeelink.mirror.bm1',
-        'miio_commands': [
-            {
-                'method': 'get_prop',
-                'params': ['nl_br'],
-                'values': True,
-            },
-        ],
+        'miio_props': ['nl_br'],
         'miio_specs': {
             'prop.2.2': {
                 'prop': 'bright',
@@ -1765,6 +1747,8 @@ MIIO_TO_MIOT_SPECS = {
             },
         },
     },
+    'yeelink.light.ceiling7': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling8': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling9': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling10': {
         'extend_model': 'yeelink.light.ceiling6',
@@ -1776,9 +1760,9 @@ MIIO_TO_MIOT_SPECS = {
         },
     },
     'yeelink.light.ceiling11': 'yeelink.light.ceiling6',
-    'yeelink.light.ceiling12': 'yeelink.light.ceiling8',
-    'yeelink.light.ceiling13': 'yeelink.light.ceiling8',
-    'yeelink.light.ceiling14': 'yeelink.light.ceiling8',
+    'yeelink.light.ceiling12': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling13': 'yeelink.light.ceiling6',
+    'yeelink.light.ceiling14': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling15': 'yeelink.light.ceiling6',
     'yeelink.light.ceiling16': {
         'extend_model': 'yeelink.light.ceiling2',


### PR DESCRIPTION
```
  yeelink.light.ceiling8
  yeelink.light.ceiling12
  yeelink.light.ceiling13
  yeelink.light.ceiling14
```
Fixed the issue where brightness readings for the mentioned model of lights were incorrect after enabling moonlight mode. https://github.com/al-one/hass-xiaomi-miot/issues/1070

I made changes only to the device model that I could test and confirm. Uncertain whether these changes apply to other models as well.


修复上述型号的灯在启用月光模式后亮度读数不正确的问题 

只修改了我可以测试的并确认工作正常的设备型号，不确定是否还有其他型号也适用。