### PR TITLE
Fix qmi.plug.tw02 energy is not updated

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -858,6 +858,7 @@ DEVICE_CUSTOMIZES = {
         'sensor_attributes': 'power_cost_today,power_cost_month',
         'sensor_properties': 'switch.temperature',
         'stat_power_cost_key': '4.1',
+        'exclude_miot_services': 'simulation',
     },
     'qmi.plug.tw02:electric_power': {
         'unit_of_measurement': 'W',


### PR DESCRIPTION
Previous PR #1272 caused the Mi Home app not to update the energy for xiaomi smart plug 2. After adding `simulation` to `exclude_miot_services` in the device_customizes.py, it can operate normally.