### PR TITLE
add energy for cuco.plug.wp5m

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -299,6 +299,27 @@ DEVICE_CUSTOMIZES = {
         'device_class': 'energy',
         'unit_of_measurement': 'kWh',
     },
+    'cuco.plug.wp5m': {
+        'main_miot_services': 'switch-2',
+        'sensor_attributes': 'power_cost_today,power_cost_month',
+        'stat_power_cost_key': '3.1',
+        'chunk_properties': 1,
+    },
+    'cuco.plug.wp5m:electric_power': {
+        'unit_of_measurement': 'W',
+    },
+    'cuco.plug.wp5m:power_cost_today': {
+        'value_ratio': 0.01,
+        'state_class': 'total_increasing',
+        'device_class': 'energy',
+        'unit_of_measurement': 'kWh',
+    },
+    'cuco.plug.wp5m:power_cost_month': {
+        'value_ratio': 0.01,
+        'state_class': 'total_increasing',
+        'device_class': 'energy',
+        'unit_of_measurement': 'kWh',
+    },    
     'cuco.plug.*': {
         'main_miot_services': 'switch-2',
     },

--- a/custom_components/xiaomi_miot/core/miot_local_devices.py
+++ b/custom_components/xiaomi_miot/core/miot_local_devices.py
@@ -106,6 +106,7 @@ MIOT_LOCAL_MODELS = [
     'cuco.plug.p8amd',
     'cuco.plug.sp5',
     'cuco.plug.v3',
+    'cuco.plug.wp5m',
     'cykj.hood.jyj22',
     'daolai.light.xd340',
     'dayang.mosq.qqtq4',


### PR DESCRIPTION
Refer to https://home.miot-spec.com/spec/cuco.plug.wp5m to set properties

![2023-09-11 18 19 43](https://github.com/al-one/hass-xiaomi-miot/assets/306544/b7309d98-f158-42bc-8d4e-5b0f01e6fc74)
