### PR TITLE
Fully customize cover open/close texts and support "stopped" status

### DIFF
--- a/custom_components/xiaomi_miot/cover.py
+++ b/custom_components/xiaomi_miot/cover.py
@@ -108,8 +108,8 @@ class MiotCoverEntity(MiotEntity, CoverEntity):
 
         self._motor_reverse = self.custom_config_bool('motor_reverse', False)
         self._position_reverse = self.custom_config_bool('position_reverse', self._motor_reverse)
-        self._open_texts = self.custom_config_list(key='open_texts', default=['Opening', 'Opened', 'Open', 'Up', 'Rising', 'Risen', 'Rise'])
-        self._close_texts = self.custom_config_list(key='close_texts', default=['Closing', 'Closed', 'Close', 'Down', 'Falling', 'Descent'])
+        self._open_texts = self.custom_config_list('open_texts', ['Opening', 'Opened', 'Open', 'Up', 'Rising', 'Risen', 'Rise'])
+        self._close_texts = self.custom_config_list('close_texts', ['Closing', 'Closed', 'Close', 'Down', 'Falling', 'Descent'])
         if self._motor_reverse:
             self._open_texts, self._close_texts = self._close_texts, self._open_texts
 
@@ -167,7 +167,7 @@ class MiotCoverEntity(MiotEntity, CoverEntity):
             # If the motor controller is stopped, generate fake middle position
             if self._prop_status:
                 sta = int(self._prop_status.from_dict(self._state_attrs) or -1)
-                if sta in self._prop_status.list_search("Stopped"):
+                if sta in self._prop_status.list_search('Stopped'):
                     return 50
             return None
         dev = int(self.custom_config_integer('deviated_position', 1) or 0)

--- a/custom_components/xiaomi_miot/cover.py
+++ b/custom_components/xiaomi_miot/cover.py
@@ -108,14 +108,8 @@ class MiotCoverEntity(MiotEntity, CoverEntity):
 
         self._motor_reverse = self.custom_config_bool('motor_reverse', False)
         self._position_reverse = self.custom_config_bool('position_reverse', self._motor_reverse)
-        self._open_texts = [
-            *(self.custom_config_list('open_texts') or []),
-            'Opening', 'Opened', 'Open', 'Up', 'Rising', 'Risen', 'Rise',
-        ]
-        self._close_texts = [
-            *(self.custom_config_list('close_texts') or []),
-            'Closing', 'Closed', 'Close', 'Down', 'Falling', 'Descent',
-        ]
+        self._open_texts = self.custom_config_list(key='open_texts', default=['Opening', 'Opened', 'Open', 'Up', 'Rising', 'Risen', 'Rise'])
+        self._close_texts = self.custom_config_list(key='close_texts', default=['Closing', 'Closed', 'Close', 'Down', 'Falling', 'Descent'])
         if self._motor_reverse:
             self._open_texts, self._close_texts = self._close_texts, self._open_texts
 
@@ -170,6 +164,11 @@ class MiotCoverEntity(MiotEntity, CoverEntity):
             elif range_max != 100:
                 pos = cur / range_max * 100
         if pos < 0:
+            # If the motor controller is stopped, generate fake middle position
+            if self._prop_status:
+                sta = int(self._prop_status.from_dict(self._state_attrs) or -1)
+                if sta in self._prop_status.list_search("Stopped"):
+                    return 50
             return None
         dev = int(self.custom_config_integer('deviated_position', 1) or 0)
         if pos <= dev:


### PR DESCRIPTION
This PR is mainly for addressing issues with [zinguo.motor.mk01](https://home.miot-spec.com/s/zinguo.motor.mk01).

The current implementation's open and close texts are too wide. They can't differentiate between stationary status open/close, and moving status opening/closing. The custom config list is just appending with the default texts, which is not helpful at all.

This PR changed the code to fully take the custom config list if available, and fall back to the default texts when no custom config found.

Additionally, this motor has no current position property, but does have a "Stopped" status. We can use this status to generate a fake 50% position so that we can use Home Assistant GUI to further open or close the cover.