### PR TITLE
Add mode and fan_level to zhimi.airp.mb5a

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1288,7 +1288,7 @@ DEVICE_CUSTOMIZES = {
     'zhimi.airp.mb5a': {
         'sensor_properties': 'moto_speed_rpm,filter_used_debug',
         'switch_properties': 'anion,alarm',
-        'select_properties': 'brightness,temperature_display_unit',
+        'select_properties': 'brightness,temperature_display_unit,fan_level,mode',
         'number_properties': 'favorite_speed,favorite_level',
     },
     'zhimi.airp.sa4': {


### PR DESCRIPTION
I found the integration lacking these features to be able to use the originally defined modes.

Used the values from here: https://home.miot-spec.com/spec/zhimi.airp.mb5a

Looks like this after having the changes done locally:
<img width="722" alt="Screenshot 2023-10-23 at 14 12 03" src="https://github.com/al-one/hass-xiaomi-miot/assets/9072730/5c758137-f6dd-403f-8f82-1b2809e42faf">
