### PR TITLE
Reverse_state of mmgg.pet_waterer.wi11:no_water_flag

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -857,6 +857,9 @@ DEVICE_CUSTOMIZES = {
         'sensor_properties': 'remain_clean_time,fault,filter_left_time,no_water_time',
         'select_properties': 'mode',
     },
+    'mmgg.pet_waterer.wi11:no_water_flag': {
+         'reverse_state': True,
+    },
     'mmgg.pet_waterer.s1': {
         'binary_sensor_properties': 'no_water_flag,pump_block_flag,lid_up_flag',
         'button_actions': 'reset_filter_life,reset_clean_time',


### PR DESCRIPTION
No Water Flag of pet_waterer.wi11 is reversed. 

Use `reverse_state` at device_customizes.py to fix that.

Issue https://github.com/al-one/hass-xiaomi-miot/issues/1316