### PR TITLE
Chinese translation for water_heater.mode

### DIFF
--- a/custom_components/xiaomi_miot/core/translation_languages.py
+++ b/custom_components/xiaomi_miot/core/translation_languages.py
@@ -316,6 +316,11 @@ TRANSLATION_LANGUAGES = {
         'water_heater': {
             'water heater': '热水器',
         },
+        'water_heater.mode': {
+            'low': '低温',
+            'medium': '中温',
+            'high': '高温'
+        },
         'airer': {
             'airer': '晾衣架',
             'dryer': '干燥功能',


### PR DESCRIPTION
For model: `zimi.waterheater.h03`

Reference Instructions: [Here](https://home.mi.com/views/introduction.html?region=cn&pdid=10164&model=zimi.waterheater.h03)

<img width="1750" alt="image" src="https://github.com/al-one/hass-xiaomi-miot/assets/15612469/72742e13-82ff-47d2-aaf3-49aa00ae6249">

Maybe this property has another values but I dont know because I have this model only :(