### PR TITLE
🔧 replace deprecated constants

### DIFF
--- a/custom_components/xiaomi_miot/core/miot_spec.py
+++ b/custom_components/xiaomi_miot/core/miot_spec.py
@@ -745,13 +745,13 @@ class MiotProperty(MiotSpecInstance):
         name = self.name
         unit = self.unit
         aliases = {
-            'celsius': TEMP_CELSIUS,
-            'fahrenheit': TEMP_FAHRENHEIT,
-            'kelvin': TEMP_KELVIN,
+            'celsius': UnitOfTemperature.CELSIUS,
+            'fahrenheit': UnitOfTemperature.FAHRENHEIT,
+            'kelvin': UnitOfTemperature.KELVIN,
             'percentage': PERCENTAGE,
             'lux': LIGHT_LUX,
-            'watt': POWER_WATT,
-            'pascal': PRESSURE_PA,
+            'watt': UnitOfPower.WATT,
+            'pascal': UnitOfPressure.PA,
             'μg/m3': CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             'mg/m3': CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
             'p/m3': CONCENTRATION_PARTS_PER_CUBIC_METER,
@@ -759,9 +759,9 @@ class MiotProperty(MiotSpecInstance):
         names = {
             'current_step_count': 'steps',
             'heart_rate': 'bpm',
-            'power_consumption': ENERGY_WATT_HOUR,
-            'electric_current': ELECTRIC_CURRENT_AMPERE,
-            'voltage': ELECTRIC_POTENTIAL_VOLT,
+            'power_consumption': UnitOfEnergy.WATT_HOUR,
+            'electric_current': UnitOfElectricCurrent.AMPERE,
+            'voltage': UnitOfElectricPotential.VOLT,
             'pm2_5_density': CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             'tds_in': CONCENTRATION_PARTS_PER_MILLION,
             'tds_out': CONCENTRATION_PARTS_PER_MILLION,

--- a/custom_components/xiaomi_miot/device_tracker.py
+++ b/custom_components/xiaomi_miot/device_tracker.py
@@ -7,7 +7,7 @@ from homeassistant.const import *  # noqa: F401
 from homeassistant.components.device_tracker import (
     DOMAIN as ENTITY_DOMAIN,
 )
-from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
 from . import (
@@ -108,7 +108,7 @@ class MiotTrackerEntity(MiotEntity, TrackerEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     @property
     def latitude(self):

--- a/custom_components/xiaomi_miot/sensor.py
+++ b/custom_components/xiaomi_miot/sensor.py
@@ -535,7 +535,7 @@ class WaterPurifierYunmiEntity(MiioEntity, Entity):
         self._subs = {
             'tds_in':  {'keys': ['tds_warn_thd'], 'unit': CONCENTRATION_PARTS_PER_MILLION, 'icon': 'mdi:water'},
             'tds_out': {'keys': ['tds_warn_thd'], 'unit': CONCENTRATION_PARTS_PER_MILLION, 'icon': 'mdi:water-check'},
-            'temperature': {'class': SensorDeviceClass.TEMPERATURE, 'unit': TEMP_CELSIUS},
+            'temperature': {'class': SensorDeviceClass.TEMPERATURE, 'unit': UnitOfTemperature.CELSIUS},
         }
         for i in [1, 2, 3]:
             self._subs.update({
@@ -546,7 +546,7 @@ class WaterPurifierYunmiEntity(MiioEntity, Entity):
                 },
                 f'f{i}_remain_days': {
                     'keys': [f'f{i}_totaltime', f'f{i}_usedtime'],
-                    'unit': TIME_DAYS,
+                    'unit': UnitOfTime.DAYS,
                     'icon': 'mdi:clock',
                 },
             })

--- a/custom_components/xiaomi_miot/water_heater.py
+++ b/custom_components/xiaomi_miot/water_heater.py
@@ -138,13 +138,13 @@ class MiotWaterHeaterEntity(MiotToggleEntity, WaterHeaterEntity):
     def temperature_unit(self):
         prop = self._prop_temperature or self._prop_target_temp
         if prop:
-            if prop.unit in ['celsius', TEMP_CELSIUS]:
-                return TEMP_CELSIUS
-            if prop.unit in ['fahrenheit', TEMP_FAHRENHEIT]:
-                return TEMP_FAHRENHEIT
-            if prop.unit in ['kelvin', TEMP_KELVIN]:
-                return TEMP_KELVIN
-        return TEMP_CELSIUS
+            if prop.unit in ['celsius', UnitOfTemperature.CELSIUS]:
+                return UnitOfTemperature.CELSIUS
+            if prop.unit in ['fahrenheit', UnitOfTemperature.FAHRENHEIT]:
+                return UnitOfTemperature.FAHRENHEIT
+            if prop.unit in ['kelvin', UnitOfTemperature.KELVIN]:
+                return UnitOfTemperature.KELVIN
+        return UnitOfTemperature.CELSIUS
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
   "zip_release": true,
   "filename": "xiaomi_miot.zip",
   "render_readme": true,
-  "homeassistant": "2022.7.0"
+  "homeassistant": "2023.1.0"
 }


### PR DESCRIPTION
Fix error in HA 2024.1

see https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation

This increase the minimum HA version requirement to 2022.11