### PR TITLE
zhimi.airp.rma3 added additional properties

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1348,6 +1348,12 @@ DEVICE_CUSTOMIZES = {
         'brightness_for_off': 2,
         'button_actions': 'reset_filter_life',
     },
+    'zhimi.airp.rma3': {
+        'sensor_properties': 'moto_speed_rpm',
+        'switch_properties': 'alarm',
+        'select_properties': 'brightness',
+        'number_properties': 'air_purifier_favorite.fan_level',
+    },
     'zhimi.airpurifier.*': {
         'speed_property': 'favorite_level,favorite_fan_level',
         'number_properties': 'favorite_level,favorite_fan_level',


### PR DESCRIPTION
[Xiaomi Air Purifier 4 Lite](https://home.miot-spec.com/s/zhimi.airp.rma3). Added support for:
- changing fan speed level
- changing screen brightness
- switching alarm sound
- motor speed sensor

| Additional Sensors  | Fan speed   | 
|---|---|
| ![CleanShot 2024-01-02 at 14 26 18@2x](https://github.com/al-one/hass-xiaomi-miot/assets/36267146/8c0f704e-808a-445c-b43a-2891cc2071d9)  | ![CleanShot 2024-01-02 at 14 32 15@2x](https://github.com/al-one/hass-xiaomi-miot/assets/36267146/c37d3615-9263-4404-a3c5-04162f6dc065)| 