### PR TITLE
Improve viomi.fridge.m1  viomi.juicer.v1  viomi.oven.so1

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1242,14 +1242,9 @@ MIIO_TO_MIOT_SPECS = {
     'viomi.fridge.m1': {
         # ["Mode","RCSetTemp","FCSetTemp","RCSet","Error","IndoorTemp","SmartCool","SmartFreeze"]
         # ["none",8          ,-15        ,"on"   ,0      ,30          ,"off"      ,"off"]
-        # 'chunk_properties': 8,
-        'miio_commands': [
-            {
-                'method': 'get_prop',
-                'params': ['RCSetTemp','FCSetTemp', 'RCSet', 'ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
-                'values': ['RCSetTemp','FCSetTemp', 'RCSet', 'ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
-            },
-        ],
+        'chunk_properties': 1,
+        'miio_props': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
+        'entity_attrs': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
         'miio_specs': {
             'prop.2.1': {'prop': 'Mode', 'setter': 'setMode', 'dict': {
                 'smart': 1,
@@ -1267,7 +1262,8 @@ MIIO_TO_MIOT_SPECS = {
     'viomi.juicer.v1': {
         # ["work_status","run_status","mode","cooked_time","curr_tempe","cook_start","rev","stand_top_num","mode_sort"        ,"cook_status","warm_time","cook_time","left_time","voice"]
         # [0,           ,768         ,7     ,0            ,-300        ,1699143554  ,0    ,0              ,'7-8-9-4-3-1-5-2-6',1            ,6514       ,1668       ,0          ,0      ]
-        'entity_attrs': ['work_status', 'run_status', 'mode', 'cooked_time', 'curr_tempe', 'cook_start', 'rev', 'stand_top_num', 'mode_sort', 'cook_status', 'warm_time', 'cook_time', 'left_time', 'voice'],
+        'miio_props': ['work_status', 'run_status', 'mode', 'cooked_time', 'cook_start', 'rev', 'stand_top_num', 'mode_sort', 'warm_time', 'cook_time',  'voice'],
+        'entity_attrs': ['work_status', 'run_status', 'mode', 'cooked_time', 'cook_start', 'rev', 'stand_top_num', 'mode_sort', 'warm_time', 'cook_time',  'voice'],
         'chunk_properties': 1,
         'miio_specs': {
             'prop.2.1': {'prop': 'cook_status'},
@@ -1330,7 +1326,8 @@ MIIO_TO_MIOT_SPECS = {
     'viomi.oven.so1': {
         # methods:
         # ['get_prop', 'setDish', 'deleteDish', 'getDishs', 'setStartDish', 'setStartMode', 'setPrepareDish', 'setPrepareMode', 'setPause', 'canclePrepare', 'setEnd', 'setBootUp', 'setTurnOff'];
-        'entity_attrs': ['hwInfo', 'swInfo', 'error', 'dishId', 'dishName', 'status', 'mode', 'workTime', 'temp', 'leftTime', 'tempSetZ', 'timeSetZ', 'tempSetK', 'timeSetK', 'waterTank', 'prepareTime', 'doorIsOpen'],
+        'miio_props': ['hwInfo', 'swInfo', 'error', 'dishId', 'dishName',  'tempSetZ', 'timeSetZ', 'tempSetK', 'timeSetK', 'waterTank', 'prepareTime', 'doorIsOpen'],
+        'entity_attrs': ['hwInfo', 'swInfo', 'error', 'dishId', 'dishName',  'tempSetZ', 'timeSetZ', 'tempSetK', 'timeSetK', 'waterTank', 'prepareTime', 'doorIsOpen'],
         'chunk_properties': 1,
         'miio_specs': {
             'prop.2.1': {'prop': 'status', 'dict': {


### PR DESCRIPTION
提升获取更多设备厂商可获取的属性以供使用。
例如：viomi.fridge.m1 
的Indoortemp属性代表室内温度，可供获取到冰箱所在室内的温度以供使用，如此用户可以省掉一个温度传感器。
viomi.oven.so1的waterTank表示水箱是否缺水，doorIsOpen表示烤箱门是否开启，这些都是比较有用的属性可以用来方便触发一些自动化。