### PR TITLE
Fix wildcard imports

### DIFF
--- a/custom_components/xiaomi_miot/__init__.py
+++ b/custom_components/xiaomi_miot/__init__.py
@@ -14,7 +14,19 @@ from homeassistant import (
     core as hass_core,
     config_entries,
 )
-from homeassistant.const import *
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_TOKEN,
+    CONF_USERNAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+    SERVICE_RELOAD,
+)
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import (

--- a/custom_components/xiaomi_miot/alarm_control_panel.py
+++ b/custom_components/xiaomi_miot/alarm_control_panel.py
@@ -1,8 +1,13 @@
 """Support alarm_control_panel entity for Xiaomi Miot."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
-from homeassistant.components.alarm_control_panel.const import *
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
+    STATE_ALARM_TRIGGERED,
+)
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ENTITY_DOMAIN,
     AlarmControlPanelEntity,

--- a/custom_components/xiaomi_miot/binary_sensor.py
+++ b/custom_components/xiaomi_miot/binary_sensor.py
@@ -5,7 +5,11 @@ import json
 from functools import partial
 from datetime import datetime
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+        STATE_OFF,
+        STATE_ON,
+        STATE_UNKNOWN,
+)
 from homeassistant.components.binary_sensor import (
     DOMAIN as ENTITY_DOMAIN,
     BinarySensorEntity,

--- a/custom_components/xiaomi_miot/button.py
+++ b/custom_components/xiaomi_miot/button.py
@@ -1,7 +1,6 @@
 """Support button entity for Xiaomi Miot."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.button import (
     DOMAIN as ENTITY_DOMAIN,
     ButtonEntity,

--- a/custom_components/xiaomi_miot/camera.py
+++ b/custom_components/xiaomi_miot/camera.py
@@ -12,7 +12,7 @@ from functools import partial
 from urllib.parse import urlencode
 from datetime import datetime, timedelta
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
 from homeassistant.components.camera import (
     DOMAIN as ENTITY_DOMAIN,

--- a/custom_components/xiaomi_miot/climate.py
+++ b/custom_components/xiaomi_miot/climate.py
@@ -2,8 +2,22 @@
 import logging
 from enum import Enum
 
-from homeassistant.const import *  # noqa: F401
-from homeassistant.components.climate.const import *
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_TEMPERATURE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
+from homeassistant.components.climate.const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_HVAC_MODE,
+    DEFAULT_MAX_HUMIDITY,
+    DEFAULT_MIN_HUMIDITY,
+    HVACAction,
+    HVACMode,
+)
 from homeassistant.components.climate import (
     DOMAIN as ENTITY_DOMAIN,
     ClimateEntity,

--- a/custom_components/xiaomi_miot/config_flow.py
+++ b/custom_components/xiaomi_miot/config_flow.py
@@ -6,7 +6,14 @@ import requests
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import *
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
 from homeassistant.core import callback, split_entity_id
 from homeassistant.util import yaml
 from homeassistant.components import persistent_notification

--- a/custom_components/xiaomi_miot/core/miot_spec.py
+++ b/custom_components/xiaomi_miot/core/miot_spec.py
@@ -5,7 +5,20 @@ import random
 import time
 import re
 
-from homeassistant.const import *
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_MILLION,
+    LIGHT_LUX,
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfTemperature,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/xiaomi_miot/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_miot/core/xiaomi_cloud.py
@@ -12,8 +12,8 @@ from functools import partial
 from urllib import parse
 
 from homeassistant.const import (
-    CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_USERNAME,
 )
 from homeassistant.helpers.storage import Store
 from homeassistant.components import persistent_notification

--- a/custom_components/xiaomi_miot/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_miot/core/xiaomi_cloud.py
@@ -11,7 +11,10 @@ from datetime import datetime
 from functools import partial
 from urllib import parse
 
-from homeassistant.const import *
+from homeassistant.const import (
+    CONF_USERNAME,
+    CONF_PASSWORD,
+)
 from homeassistant.helpers.storage import Store
 from homeassistant.components import persistent_notification
 

--- a/custom_components/xiaomi_miot/cover.py
+++ b/custom_components/xiaomi_miot/cover.py
@@ -5,7 +5,11 @@ from enum import Enum
 from functools import partial
 from datetime import timedelta
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_HOST,
+    CONF_TOKEN,
+)
 from homeassistant.core import callback
 from homeassistant.components.cover import (
     DOMAIN as ENTITY_DOMAIN,

--- a/custom_components/xiaomi_miot/device_tracker.py
+++ b/custom_components/xiaomi_miot/device_tracker.py
@@ -3,7 +3,6 @@ import logging
 import time
 from datetime import timedelta
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.device_tracker import (
     DOMAIN as ENTITY_DOMAIN,
 )

--- a/custom_components/xiaomi_miot/fan.py
+++ b/custom_components/xiaomi_miot/fan.py
@@ -1,7 +1,6 @@
 """Support for Xiaomi fans."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.fan import (
     DOMAIN as ENTITY_DOMAIN,
     FanEntity,

--- a/custom_components/xiaomi_miot/humidifier.py
+++ b/custom_components/xiaomi_miot/humidifier.py
@@ -1,8 +1,10 @@
 """Support for humidifier and dehumidifier."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
-from homeassistant.components.humidifier.const import *
+from homeassistant.components.humidifier.const import (
+    DEFAULT_MAX_HUMIDITY,
+    DEFAULT_MIN_HUMIDITY,
+)
 from homeassistant.components.humidifier import (
     DOMAIN as ENTITY_DOMAIN,
     HumidifierEntity,

--- a/custom_components/xiaomi_miot/light.py
+++ b/custom_components/xiaomi_miot/light.py
@@ -2,7 +2,6 @@
 import logging
 from functools import partial
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.light import (
     DOMAIN as ENTITY_DOMAIN,
     LightEntity,

--- a/custom_components/xiaomi_miot/media_player.py
+++ b/custom_components/xiaomi_miot/media_player.py
@@ -11,14 +11,22 @@ from datetime import timedelta
 from functools import partial
 from urllib.parse import urlencode, urlparse, parse_qsl
 
-from homeassistant.const import *  # noqa: F401
-from homeassistant.components.media_player.const import *
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_FRIENDLY_NAME,
+    CONF_HOST,
+)
+from homeassistant.components.media_player.const import ( 
+    MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_VIDEO,
+    RepeatMode,
+)
 from homeassistant.components.media_player import (
     DOMAIN as ENTITY_DOMAIN,
-    MediaPlayerEntity,
-    MediaPlayerState,  # v2022.10
-    MediaPlayerEntityFeature,  # v2022.5
     MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,  # v2022.5
+    MediaPlayerState,  # v2022.10
 )
 from homeassistant.components.homekit.const import EVENT_HOMEKIT_TV_REMOTE_KEY_PRESSED
 from homeassistant.core import HassJob
@@ -422,10 +430,10 @@ class MiotMediaPlayerEntity(MiotEntity, BaseMediaPlayerEntity):
                 if self._attr_volume_level is not None:
                     self._attr_volume_level = self._attr_volume_level / 100
                 self._attr_repeat = {
-                    0: REPEAT_MODE_ONE,
-                    1: REPEAT_MODE_ALL,
-                    3: REPEAT_MODE_OFF,  # random
-                }.get(info.get('loop_type'), REPEAT_MODE_OFF)
+                    0: RepeatMode.ONE,
+                    1: RepeatMode.ALL,
+                    3: RepeatMode.OFF,  # random
+                }.get(info.get('loop_type'), RepeatMode.OFF)
 
                 self._attr_media_content_id = mid
                 self._attr_media_title = song.get('title') or song.get('name')

--- a/custom_components/xiaomi_miot/number.py
+++ b/custom_components/xiaomi_miot/number.py
@@ -1,7 +1,6 @@
 """Support number entity for Xiaomi Miot."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.number import (
     DOMAIN as ENTITY_DOMAIN,
     NumberEntity,

--- a/custom_components/xiaomi_miot/remote.py
+++ b/custom_components/xiaomi_miot/remote.py
@@ -3,7 +3,10 @@ import logging
 import time
 from functools import partial
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_TOKEN,
+)
 from homeassistant.components import remote
 from homeassistant.components.remote import (
     DOMAIN as ENTITY_DOMAIN,

--- a/custom_components/xiaomi_miot/select.py
+++ b/custom_components/xiaomi_miot/select.py
@@ -1,7 +1,6 @@
 """Support select entity for Xiaomi Miot."""
 import logging
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.select import (
     DOMAIN as ENTITY_DOMAIN,
     SelectEntity,

--- a/custom_components/xiaomi_miot/sensor.py
+++ b/custom_components/xiaomi_miot/sensor.py
@@ -6,7 +6,16 @@ from typing import cast
 from datetime import datetime, timedelta
 from functools import partial, cmp_to_key
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_TOKEN,
+    PERCENTAGE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.helpers.entity import (
     Entity,
 )

--- a/custom_components/xiaomi_miot/switch.py
+++ b/custom_components/xiaomi_miot/switch.py
@@ -2,7 +2,13 @@
 import logging
 import time
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_TOKEN,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.components.switch import (
     DOMAIN as ENTITY_DOMAIN,
     SwitchEntity,

--- a/custom_components/xiaomi_miot/text.py
+++ b/custom_components/xiaomi_miot/text.py
@@ -2,7 +2,6 @@
 import logging
 import time
 
-from homeassistant.const import *  # noqa: F401
 from homeassistant.components.text import (
     DOMAIN as ENTITY_DOMAIN,
     TextEntity,

--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -4,7 +4,10 @@ import time
 from datetime import timedelta
 from functools import partial
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    STATE_IDLE,
+    STATE_PAUSED,
+)
 from homeassistant.components.vacuum import (  # noqa: F401
     DOMAIN as ENTITY_DOMAIN,
     StateVacuumEntity,

--- a/custom_components/xiaomi_miot/water_heater.py
+++ b/custom_components/xiaomi_miot/water_heater.py
@@ -2,7 +2,12 @@
 import logging
 import math
 
-from homeassistant.const import *  # noqa: F401
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    STATE_OFF,
+    STATE_ON,
+    UnitOfTemperature,
+)
 from homeassistant.components.water_heater import (
     DOMAIN as ENTITY_DOMAIN,
     WaterHeaterEntity,


### PR DESCRIPTION
Since 2024.1.1 HA warns for a lot of deprecated constants used by this component. These constants were imported with wildcards and mostly not even used. I had 3159 lines of warnings in my log. To fix this, I've removed all wildcard imports and replaced them with specific imports.

I only have a purifier device at home in use with this component, so the changes should be tested with other devices too.

Fixes #1483