### PR TITLE
Decrease logging level when there are no messages waiting in sensor.py

### DIFF
--- a/custom_components/xiaomi_miot/sensor.py
+++ b/custom_components/xiaomi_miot/sensor.py
@@ -726,7 +726,12 @@ class MihomeMessageSensor(MiCoordinatorEntity, SensorEntity, RestoreEntity):
             break
         if not mls:
             if not self._has_none_message:
-                _LOGGER.warning('Get xiaomi message for %s failed: %s', self.cloud.user_id, res)
+                # Only raise a warning if there was a failure obtaining the xiaomi message
+                # Otherwise, a warning will show anytime that there are simply no messages waiting
+                if res['code'] == 0 and res['message'] == 'ok':
+                    _LOGGER.debug('Get xiaomi message for %s failed: %s', self.cloud.user_id, res)
+                else:
+                    _LOGGER.warning('Get xiaomi message for %s failed: %s', self.cloud.user_id, res)
             self._has_none_message = True
         if msg:
             await self.async_set_message(msg)


### PR DESCRIPTION
Removes over-the-top logging every time that the integration faces the issue that there are no notifications waiting.