### PR TITLE
修复zhimi.airp.vb4中pm10单位为None的问题

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1411,6 +1411,9 @@ DEVICE_CUSTOMIZES = {
         'select_properties': 'brightness',
         'number_properties': 'air_purifier_favorite.fan_level',
     },
+    'zhimi.airp.vb4:pm10-density': {
+        'unit_of_measurement': 'µg/m³',
+    },
     'zhimi.airpurifier.*': {
         'speed_property': 'favorite_level,favorite_fan_level',
         'number_properties': 'favorite_level,favorite_fan_level',


### PR DESCRIPTION
修复zhimi.airp.vb4中pm10单位为None的问题

相关issue: Error: pm10 is using 'None' unit of measurement - expected 'µg/m³' #1542