### PR TITLE
修复zhimi.airp.meb1中pm10单位为None的问题

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1397,6 +1397,9 @@ DEVICE_CUSTOMIZES = {
         'select_properties': 'brightness,temperature_display_unit',
         'number_properties': 'favorite_speed,favorite_level',
     },
+    'zhimi.airp.meb1:pm10-density': {
+        'unit_of_measurement': 'µg/m³',
+    },
     'zhimi.airp.sa4': {
         'switch_properties': 'alarm',
         'number_properties': 'air_purifier_favorite.fan_level,aqi_updata_heartbeat',


### PR DESCRIPTION
修复zhimi.airp.meb1中pm10单位为None的问题

相关issue:
https://github.com/al-one/hass-xiaomi-miot/issues/1418