### PR TITLE
improve temperature unit for zhimi.airpurifier.vb2

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1501,6 +1501,9 @@ DEVICE_CUSTOMIZES = {
         'switch_properties': 'alarm',
         'number_properties': 'favorite_speed,aqi_updata_heartbeat,brightness',
     },
+    'zhimi.airpurifier.vb2:temperature': {
+        'unit_of_measurement': '°C',
+    },
     'zhimi.airpurifier.za1': {
         'brightness_for_on': 0,
         'brightness_for_off': 2,


### PR DESCRIPTION
improve temperature unit for [zhimi.airpurifier.vb2](https://home.miot-spec.com/s/zhimi.airpurifier.vb2)

issue:https://github.com/al-one/hass-xiaomi-miot/issues/1442