### PR TITLE
fix xiaoai x08A & xl04 playback status

### DIFF
--- a/custom_components/xiaomi_miot/media_player.py
+++ b/custom_components/xiaomi_miot/media_player.py
@@ -185,6 +185,12 @@ class BaseMediaPlayerEntity(MediaPlayerEntity, MiotEntityInterface, BaseEntity):
         if self._prop_state:
             sta = self._prop_state.from_dict(self._state_attrs)
             if sta is not None:
+                if self._state_attrs['speaker.mute'] == False :
+                    new_state = {'playing_state': 1}
+                    self._state_attrs.update(new_state)
+                else:
+                    new_state = {'playing_state': 2}
+                    self._state_attrs.update(new_state)
                 if sta in self._prop_state.list_search('Playing', 'Play'):
                     return MediaPlayerState.PLAYING
                 if sta == self._prop_state.list_value('Pause'):
@@ -443,6 +449,7 @@ class MiotMediaPlayerEntity(MiotEntity, BaseMediaPlayerEntity):
                 self._attr_media_image_remotely_accessible = False
                 self._attr_media_duration = int(song['duration'] / 1000) if 'duration' in song else None
                 self._attr_media_position = int(song['position'] / 1000) if 'position' in song else None
+                self._attr_media_position_updated_at = utcnow()
             if not self._attr_state:
                 self.logger.info('%s: Got empty media info: %s', self.name_model, result)
         except (TypeError, ValueError, Exception) as exc:


### PR DESCRIPTION
The problem description is as follows: # 1482. The playing_state of these two models is unreadable, with a minimum volume of 5. The speaker. mute corresponds to its playback status, so the playing_state was manually corrected. After a period of testing, everything was normal.