### PR TITLE
Improve viomi.fridge.m1

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1271,6 +1271,9 @@ DEVICE_CUSTOMIZES = {
             2: 0,    # Descent-limit
         },
     },
+    'viomi.fridge.m1': {
+        'sensor_properties': 'fridge.temperature',
+    },
     'viomi.hood.v1': {
         'main_miot_services': 'hood-2',
         'number_properties': 'off_delay_time',

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1243,13 +1243,9 @@ MIIO_TO_MIOT_SPECS = {
         # ["Mode","RCSetTemp","FCSetTemp","RCSet","Error","IndoorTemp","SmartCool","SmartFreeze"]
         # ["none",8          ,-15        ,"on"   ,0      ,30          ,"off"      ,"off"]
         # 'chunk_properties': 8,
-        'miio_commands': [
-            {
-                'method': 'get_prop',
-                'params': ['RCSetTemp','FCSetTemp', 'RCSet', 'ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
-                'values': ['RCSetTemp','FCSetTemp', 'RCSet', 'ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
-            },
-        ],
+        'chunk_properties': 1,
+        'miio_props': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
+        'entity_attrs': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
         'miio_specs': {
             'prop.2.1': {'prop': 'Mode', 'setter': 'setMode', 'dict': {
                 'smart': 1,

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -1244,8 +1244,8 @@ MIIO_TO_MIOT_SPECS = {
         # ["none",8          ,-15        ,"on"   ,0      ,30          ,"off"      ,"off"]
         # 'chunk_properties': 8,
         'chunk_properties': 1,
-        'miio_props': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
-        'entity_attrs': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze', 'IndoorTemp'],
+        'miio_props': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze'],
+        'entity_attrs': ['ScreenOn', 'Error', 'SmartCool', 'SmartFreeze'],
         'miio_specs': {
             'prop.2.1': {'prop': 'Mode', 'setter': 'setMode', 'dict': {
                 'smart': 1,
@@ -1258,6 +1258,7 @@ MIIO_TO_MIOT_SPECS = {
             'prop.3.3': {'prop': 'RCSetTemp'},
             'prop.4.1': {'prop': 'FCSetTemp', 'setter': 'setFCSetTemp'},
             'prop.4.2': {'prop': 'FCSetTemp'},
+            'prop.2.2': {'prop': 'IndoorTemp'},
         },
     },
     'viomi.juicer.v1': {

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -766,6 +766,22 @@
       ]
     }
   ],
+  "viomi.fridge.m1": [
+    {
+      "iid": 2,
+      "properties": [
+        {
+          "iid": 2,
+          "type": "urn:miot-spec-v2:property:temperature",
+          "description": "Indoor Temperature",
+          "format": "float",
+          "access": ["read"],
+          "unit": "celsius",
+          "value-range": [-40, 125, 1]
+        }
+      ]
+    }
+  ],
 
   "viomi.vacuum.v7": [
     {


### PR DESCRIPTION
提升获取更多设备厂商可获取的属性以供使用。
例如：viomi.fridge.m1 
的Indoortemp属性代表室内温度，可供获取到冰箱所在室内的温度以供使用，如此用户可以省掉一个温度传感器。