### PR TITLE
Add sub-entities for pet_waterer.s4 #1615

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -990,6 +990,12 @@ DEVICE_CUSTOMIZES = {
         'sensor_properties': 'remain_clean_time,fault,filter_left_time,no_water_time',
         'select_properties': 'mode',
     },
+    'mmgg.pet_waterer.s4': {
+        'binary_sensor_properties': 'no_water_flag,pump_block_flag',
+        'button_actions': 'reset_filter_life,reset_clean_time',
+        'sensor_properties': 'remain_clean_time,fault,filter_left_time,no_water_time',
+        'select_properties': 'mode',
+    },
     'mrbond.airer.m53pro': {
         'position_reverse': False,
         'sensor_properties': 'fault,left_time',


### PR DESCRIPTION
The S4 model of the Smart Pet Fountain does not have sub-entities as do the S1 and Wi11 models, this PR solves it. It's related with #1615 issue.

The lid-up subentity has not been added because this model does not support it (checked with [miiot speec](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:pet-drinking-fountain:0000A067:mmgg-s4:1) and with my own S4 running).