### PR TITLE
improve for dmaker.fan.p28

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -513,8 +513,9 @@ DEVICE_CUSTOMIZES = {
         'percentage_property': 'prop.2.6',
     },
     'dmaker.fan.p28': {
+        'switch_properties': 'alarm,horizontal_swing,vertical_swing,swing_all,off_to_center',
         'percentage_property': 'speed_level',
-        'button_properties': 'swing_updown_manual,swing_lr_manual,back_to_center',
+        'button_properties': 'swing_updown_manual,swing_lr_manual,back_to_center,start_left,start_right,start_up,start_down',
     },
     'dmaker.fan.p33': {
         'percentage_property': 'prop.2.6',


### PR DESCRIPTION
Expose more features of dmaker.fan.p28

![image](https://github.com/al-one/hass-xiaomi-miot/assets/306544/e3cf021e-dd74-4df5-80a7-f827c84aea62)
