### PR TITLE
Fix fan speed setting for NWT 18L Dehumidifier

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -804,7 +804,7 @@ MIIO_TO_MIOT_SPECS = {
                                 '["dry_cloth"] if value == 2 else '
                                 '{"method": "set_auto","params": [props.auto]} }}',
             },
-            'prop.2.3': {'prop': 'fan_st', 'setter': True},
+            'prop.2.3': {'prop': 'fan_st', 'setter': 'set_fan_level'},
             'prop.2.101': {'prop': 'auto', 'setter': True},
             'prop.2.102': {'prop': 'tank_full', 'format': 'onoff'},
             'prop.3.1': {'prop': 'humidity'},


### PR DESCRIPTION
This pull request closes #1695.

By doing a packet capture of official MiHome app, it can be observed that it performs a RPC call to method `set_fan_level` with the same parameter.

![屏幕截图 2024-06-19 185556](https://github.com/al-one/hass-xiaomi-miot/assets/16266909/736446df-2bd2-477d-9618-a393c6881aba)

By replicating the same method call through the integration, a successful operation can be observed.

![屏幕截图 2024-06-19 185606](https://github.com/al-one/hass-xiaomi-miot/assets/16266909/2074cd44-636a-487d-88d2-89b616a9f554)

I have tested with the generated fan entity and it's working on my end.
