### PR TITLE
Fix humidifier mode setting when power is off

### DIFF
--- a/custom_components/xiaomi_miot/humidifier.py
+++ b/custom_components/xiaomi_miot/humidifier.py
@@ -190,12 +190,12 @@ class MiotHumidifierEntity(MiotToggleEntity, HumidifierEntity):
     def set_mode(self, mode: str):
         if mode == MODE_OFF:
             return self.turn_off()
-        if mode != MODE_OFF and not self.is_on:
-            if not self.turn_on():
-                return False
         if not self._prop_mode:
             return False
         val = self._prop_mode.list_value(mode)
         if val is None:
             return False
+        if mode != MODE_OFF and not self.is_on:
+            if not self.turn_on():
+                return False
         return self.set_property(self._prop_mode, val)

--- a/custom_components/xiaomi_miot/humidifier.py
+++ b/custom_components/xiaomi_miot/humidifier.py
@@ -190,6 +190,9 @@ class MiotHumidifierEntity(MiotToggleEntity, HumidifierEntity):
     def set_mode(self, mode: str):
         if mode == MODE_OFF:
             return self.turn_off()
+        if mode != MODE_OFF and not self.is_on:
+            if not self.turn_on():
+                return False
         if not self._prop_mode:
             return False
         val = self._prop_mode.list_value(mode)


### PR DESCRIPTION
When the (de)humidifier is turned off, the "State" and "Mode" in the Lovelace card are both showing "Off":

![image](https://github.com/user-attachments/assets/027f8a3c-74eb-4009-89aa-10828063d71c)

However if I change mode to anything other than "Off" without first turning state to "On", nothing happens and an error can be seen in the log:
```
Storage Room Dehumidifier(nwt.derh.wdh318efw1): Set miot property {'did': 'prop.2.2', 'siid': 2, 'piid': 2, 'value': 0} failed: {'code': -5000, 'message': 'invalid operation'}
```

I think it makes sense that changing the mode during power off should firstly turn it on then set the mode. I'd love to hear more opinions about this behaviour.

Also this is only tested on [NWT 18L Dehumidifier (nwt.derh.wdh318efw1)](https://home.miot-spec.com/s/nwt.derh.wdh318efw1) since that's the only (de)humidifier I have on hand. It may need more testing with more devices.