### PR TITLE
add energy for cuco.acpartner.cp6

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -224,6 +224,20 @@ DEVICE_CUSTOMIZES = {
     },
     'cuco.acpartner.cp6': {
         'switch_properties': 'air_conditioner.on',
+        'sensor_attributes': 'power_cost_today,power_cost_month',
+        'stat_power_cost_key': '7.1',
+    },
+    'cuco.acpartner.cp6:power_cost_today': {
+        'value_ratio': 1,
+        'state_class': 'total_increasing',
+        'device_class': 'energy',
+        'unit_of_measurement': 'kWh',
+    },
+    'cuco.acpartner.cp6:power_cost_month': {
+        'value_ratio': 1,
+        'state_class': 'total_increasing',
+        'device_class': 'energy',
+        'unit_of_measurement': 'kWh',
     },
     'cuco.light.sl4': {
         'switch_properties': 'swich',


### PR DESCRIPTION
This PR is about the device expansion of energy information
add power_cost_today and power_cost_month
https://home.miot-spec.com/s/cuco.acpartner.cp6
![cp6](https://github.com/user-attachments/assets/60bc21ef-14f4-4018-ae3c-9ad387874ea2)
![IMG_5841](https://github.com/user-attachments/assets/12e3e775-64a7-48e8-8d74-c12701274e2d)
