### PR TITLE
Updated list of "cleaning" vacuum statuses to support new vacuum models

### DIFF
--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -141,9 +141,9 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
             if val is None:
                 pass
             elif val in self._prop_status.list_search(
-                'Cleaning', 'Sweeping', 'Mopping', 'Sweeping and Mopping',
+                'Cleaning', 'Sweeping', 'Mopping', 'Sweeping And Mopping', 'Washing', 'Go Washing',
                 'Part Sweeping', 'Zone Sweeping', 'Select Sweeping', 'Spot Sweeping', 'Goto Target',
-                'Starting', 'Working', 'Busy',
+                'Starting', 'Working', 'Busy', 'DustCollecting'
             ):
                 return STATE_CLEANING
             elif val in self._prop_status.list_search('Idle', 'Sleep'):


### PR DESCRIPTION
New models of Xiaomi vacuums (for instance https://home.miot-spec.com/spec/xiaomi.vacuum.c102gl) have more states corresponding to generic "cleaning" state.

I have added these states and tested it locally -- now vacuum doesn't go out of "cleaning" state while performing cleaning in modern modes like "Sweeping And Mopping".