### PR TITLE
Included Drying state in Docked category

### DIFF
--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -148,7 +148,7 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
                 return STATE_CLEANING
             elif val in self._prop_status.list_search('Idle', 'Sleep'):
                 return STATE_IDLE
-            elif val in self._prop_status.list_search('Charging', 'Charging Completed', 'Fullcharge'):
+            elif val in self._prop_status.list_search('Charging', 'Charging Completed', 'Fullcharge', 'Drying'):
                 return STATE_DOCKED
             elif val in self._prop_status.list_search('Go Charging'):
                 return STATE_RETURNING


### PR DESCRIPTION
I was continuing to work with nes models of Xiaomi vacuums (for instance https://home.miot-spec.com/spec/xiaomi.vacuum.c102gl) and found that drying state (when vacuum automatically dries pads on the station) corresponds to generic "docked" state.

I have added the state and tested it locally -- now vacuum doesn't go out into “Drying” mode when cleaning is completed and instead correctly switches to “docked” state.