### PR TITLE
Improve xiaomi.vacuum.b108gl

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1544,6 +1544,22 @@ DEVICE_CUSTOMIZES = {
         'auto_cloud': True,
         'number_properties': 'speaker.volume',
     },
+    'xiaomi.vacuum.b108gl': {
+        'sensor_properties': 'status,cleaning_area,cleaning_time,status_extend',
+        'binary_sensor_properties': 'mop_status',
+        'switch_properties': 'edge_swing_tail_sweep,carpet_discriminate,carpet_boost,sweep_break_switch',
+        'select_properties': 'sweep_mop_type,sweep_type,clean_times,suction_level,mop_water_output_level,mode,edge_sweep_frequency,carpet_cleaning_method',
+        'exclude_miot_services': 'vacuum_map',
+    },
+    'xiaomi.vacuum.b108gl:cleaning_area': {
+        'value_ratio': 0.01,
+        'unit_of_measurement': '㎡',
+    },
+    'xiaomi.vacuum.b108gl:cleaning_time': {
+        'value_ratio': 0.016666,
+        'device_class': 'duration',
+        'unit_of_measurement': 'min',
+    },
     'xiaomi.watch.*': {
         'sensor_properties': 'current_step_count,current_distance',
     },

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1545,7 +1545,7 @@ DEVICE_CUSTOMIZES = {
         'number_properties': 'speaker.volume',
     },
     'xiaomi.vacuum.b108gl': {
-        'sensor_properties': 'status,cleaning_area,cleaning_time,status_extend',
+        'sensor_properties': 'status,fault,cleaning_area,cleaning_time,status_extend',
         'binary_sensor_properties': 'mop_status',
         'switch_properties': 'edge_swing_tail_sweep,carpet_discriminate,carpet_boost,sweep_break_switch',
         'select_properties': 'sweep_mop_type,sweep_type,clean_times,suction_level,mop_water_output_level,mode,edge_sweep_frequency,carpet_cleaning_method',


### PR DESCRIPTION
This PR adds xiaomi.vacuum.b108gl related device definitions. The product name in Taiwan is "Xiaomi 掃拖機器人 S20+".

[xiaomi.vacuum.b108gl miot spec](https://home.miot-spec.com/spec/xiaomi.vacuum.b108gl)

![image](https://github.com/user-attachments/assets/d164848c-8300-49d9-a9d8-eb72e59d27f8)
