### PR TITLE
fix: The washer status should be `off` on standby status

### DIFF
--- a/custom_components/xiaomi_miot/switch.py
+++ b/custom_components/xiaomi_miot/switch.py
@@ -236,8 +236,8 @@ class MiotWasherActionSubEntity(SwitchSubEntity):
         self._name = self.format_name_by_property(miot_property)
         self._miot_property = miot_property
         self._miot_service = miot_property.service
-        self._values_on = miot_property.list_search('Busy', 'Delay')
-        self._values_off = miot_property.list_search('Off', 'Idle', 'Pause', 'Paused', 'Completed', 'Fault')
+        self._values_on = miot_property.list_search('Busy', 'Delay', 'Run')
+        self._values_off = miot_property.list_search('Off', 'Standby', 'Idle', 'Pause', 'Paused', 'Completed', 'Fault', 'END', 'E6')
 
     def update(self, data=None):
         super().update(data)


### PR DESCRIPTION
The [minij-v20:2](https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:washer:0000A01F:minij-v20:2) has following status

```
0 - Off
1 - Standby
2 - Run
3 - Pause
4 - Fault
5 - Delay
6 - END
7 - E6
```

and `Standby`, `Run`, `END` and `E6` are missing right now.