### PR TITLE
Fix deprecated constants warning in HA 2024.10

### DIFF
--- a/custom_components/xiaomi_miot/camera.py
+++ b/custom_components/xiaomi_miot/camera.py
@@ -18,8 +18,7 @@ from homeassistant.components.camera import (
     DOMAIN as ENTITY_DOMAIN,
     Camera,
     CameraEntityFeature,  # v2022.5
-    STATE_RECORDING,
-    STATE_STREAMING,
+    CameraState, # v2024.10
 )
 from homeassistant.components.ffmpeg import async_get_image, DATA_FFMPEG
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -221,10 +220,10 @@ class MiotCameraEntity(MiotToggleEntity, BaseCameraEntity):
     @property
     def state(self):  # noqa
         if self.is_recording:
-            return STATE_RECORDING
+            return CameraState.RECORDING
         if self.is_streaming:
-            return STATE_STREAMING
-        return STATE_IDLE
+            return CameraState.STREAMING
+        return CameraState.IDLE
 
     async def async_update(self):
         self._state_attrs.pop('motion_video_latest', None)  # remove
@@ -575,10 +574,10 @@ class MotionCameraEntity(BaseSubEntity, BaseCameraEntity):
     @property
     def state(self):
         if self.is_recording:
-            return STATE_RECORDING
+            return CameraState.RECORDING
         if self.is_streaming:
-            return STATE_STREAMING
-        return STATE_IDLE
+            return CameraState.STREAMING
+        return CameraState.IDLE
 
     def update(self, data=None):
         super().update(data)

--- a/custom_components/xiaomi_miot/media_player.py
+++ b/custom_components/xiaomi_miot/media_player.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_HOST,
 )
 from homeassistant.components.media_player.const import ( 
-    MediaType, # v2024.10
+    MediaType, # v2022.5
     RepeatMode,
 )
 from homeassistant.components.media_player import (

--- a/custom_components/xiaomi_miot/media_player.py
+++ b/custom_components/xiaomi_miot/media_player.py
@@ -17,8 +17,7 @@ from homeassistant.const import (
     CONF_HOST,
 )
 from homeassistant.components.media_player.const import ( 
-    MEDIA_TYPE_MUSIC,
-    MEDIA_TYPE_VIDEO,
+    MediaType, # v2024.10
     RepeatMode,
 )
 from homeassistant.components.media_player import (
@@ -432,7 +431,7 @@ class MiotMediaPlayerEntity(MiotEntity, BaseMediaPlayerEntity):
                         2: MediaPlayerState.PAUSED,
                     }.get(sta)
                 if (typ := info.get('media_type')) is not None:
-                    self._attr_media_content_type = {3: MEDIA_TYPE_MUSIC, 13: MEDIA_TYPE_VIDEO}.get(typ)
+                    self._attr_media_content_type = {3: MediaType.MUSIC, 13: MediaType.VIDEO}.get(typ)
                 else:
                     self._attr_media_content_type = song.get('audioType')
                 self._attr_volume_level = info.get('volume')


### PR DESCRIPTION
Subject says it all.

Fixes #1877 

- `CameraState` was added in HA 2024.10, so it is breaking for any HA older than this (or: it raises the minimum version for `xiaomi_miot` to HA 2024.10)
- `MediaType` was added in HA 2022.5 already, but was never marked as deprecated. This is non-breaking as you already list HA `2023.1.0` as minimum version.