### PR TITLE
❄️ add second power_cost entities for lumi.acpartner.mcn04

### DIFF
--- a/custom_components/xiaomi_miot/__init__.py
+++ b/custom_components/xiaomi_miot/__init__.py
@@ -1628,12 +1628,7 @@ class MiotEntity(MiioEntity):
 
         # update micloud statistics in cloud
         cls = self.custom_config_list('micloud_statistics') or []
-        if key := self.custom_config('stat_power_cost_key'):
-            if isinstance(key, list):
-                keys = key
-            else:
-                keys = [key]
-
+        if keys := self.custom_config_list('stat_power_cost_key'):
             for k in keys:
                 dic = {
                     'type': self.custom_config('stat_power_cost_type', 'stat_day_v3'),
@@ -1643,7 +1638,7 @@ class MiotEntity(MiioEntity):
                     'attribute': None,
                     'template': 'micloud_statistics_power_cost',
                 }
-                cls = [*cls, dic]
+                cls.append(dic)
         if cls:
             await self.async_update_micloud_statistics(cls)
 

--- a/custom_components/xiaomi_miot/__init__.py
+++ b/custom_components/xiaomi_miot/__init__.py
@@ -1159,6 +1159,22 @@ class MiotEntityInterface:
         raise NotImplementedError()
 
 
+def update_attrs_add_suffix_on_duplicate(attrs, new_dict):
+    updated_attrs = {}
+
+    for key, value in new_dict.items():
+        if key in attrs:
+            suffix = 2
+            while f"{key}_{suffix}" in attrs:
+                suffix += 1
+            updated_key = f"{key}_{suffix}"
+        else:
+            updated_key = key
+
+        updated_attrs[updated_key] = value
+    attrs.update(updated_attrs)
+
+
 class MiotEntity(MiioEntity):
     def __init__(self, miot_service=None, device=None, **kwargs):
         self._config = dict(kwargs.get('config') or {})
@@ -1613,15 +1629,21 @@ class MiotEntity(MiioEntity):
         # update micloud statistics in cloud
         cls = self.custom_config_list('micloud_statistics') or []
         if key := self.custom_config('stat_power_cost_key'):
-            dic = {
-                'type': self.custom_config('stat_power_cost_type', 'stat_day_v3'),
-                'key': key,
-                'day': 32,
-                'limit': 31,
-                'attribute': None,
-                'template': 'micloud_statistics_power_cost',
-            }
-            cls = [*cls, dic]
+            if isinstance(key, list):
+                keys = key
+            else:
+                keys = [key]
+
+            for k in keys:
+                dic = {
+                    'type': self.custom_config('stat_power_cost_type', 'stat_day_v3'),
+                    'key': k,
+                    'day': 32,
+                    'limit': 31,
+                    'attribute': None,
+                    'template': 'micloud_statistics_power_cost',
+                }
+                cls = [*cls, dic]
         if cls:
             await self.async_update_micloud_statistics(cls)
 
@@ -1788,7 +1810,7 @@ class MiotEntity(MiioEntity):
             if anm := c.get('attribute'):
                 attrs[anm] = rls
             elif isinstance(rls, dict):
-                attrs.update(rls)
+                update_attrs_add_suffix_on_duplicate(attrs, rls)
         if attrs:
             await self.async_update_attrs(attrs)
 

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -824,14 +824,25 @@ DEVICE_CUSTOMIZES = {
         'select_properties': 'ac_mode',
         'miio_cloud_props': [],
         'stat_power_cost_type': 'stat_day_v3',
-        'stat_power_cost_key': '7.1',
+        'stat_power_cost_key': ['7.1', '7.3'],
+        'sensor_attributes': 'power_cost_today,power_cost_month,power_cost_today_2,power_cost_month_2'
     },
     'lumi.acpartner.mcn04:power_consumption': ENERGY_KWH,
     'lumi.acpartner.mcn04:power_cost_today': {
         'value_ratio': 1,
+        **ENERGY_KWH
     },
     'lumi.acpartner.mcn04:power_cost_month': {
         'value_ratio': 1,
+        **ENERGY_KWH
+    },
+    'lumi.acpartner.mcn04:power_cost_today_2': {
+        'value_ratio': 1,
+        **ENERGY_KWH
+    },
+    'lumi.acpartner.mcn04:power_cost_month_2': {
+        'value_ratio': 1,
+        **ENERGY_KWH
     },
     'lumi.acpartner.*': {
         'sensor_attributes': 'electric_power,power_cost_today,power_cost_month',


### PR DESCRIPTION
lumi.acpartner.mcn04 has 2 sockets, but micloud_statistics only processed 1

so change the config stat_power_cost_key to support keys array for further similar devices.

this change will add power_cost_today/month with suffix _2, _3..., won't change the entity naming for pervious devices.

FYI: I am not very familiar with the code structure, if this pr is not the proper way to achive this, let me know.

![image](https://github.com/user-attachments/assets/fb8e2259-7c27-4a61-8e1f-3ee4eebfc4fe)
