### PR TITLE
add sensor_properties power_consumption for xiaomi.airc.r24r00

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1398,6 +1398,9 @@ DEVICE_CUSTOMIZES = {
     'xiaomi.airc.r34r00': {
         'sensor_properties': 'power_consumption',
     },
+    'xiaomi.airc.r24r00': {
+        'sensor_properties': 'power_consumption',
+    },
     'xiaomi.airc.*:power_consumption': ENERGY_KWH,
     'xiaomi.aircondition.m9': {
         'exclude_miot_services': 'machine_state,flag_bit,single_smart_scene',


### PR DESCRIPTION
https://github.com/al-one/hass-xiaomi-miot/issues/1914