### PR TITLE
fix: Update alarm_control_panel state enums

### DIFF
--- a/custom_components/xiaomi_miot/alarm_control_panel.py
+++ b/custom_components/xiaomi_miot/alarm_control_panel.py
@@ -1,13 +1,6 @@
 """Support alarm_control_panel entity for Xiaomi Miot."""
 import logging
 
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED,
-)
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ENTITY_DOMAIN,
     AlarmControlPanelEntity,
@@ -89,17 +82,17 @@ class MiotAlarmEntity(MiotEntity, AlarmControlPanelEntity):
             if des is not None:
                 des = f'{des}'.lower()
                 if 'basic' in des:
-                    self._attr_state = STATE_ALARM_DISARMED
+                    self._attr_state = AlarmControlPanelState.DISARMED
                 elif 'home' in des:
-                    self._attr_state = STATE_ALARM_ARMED_HOME
+                    self._attr_state = AlarmControlPanelState.ARMED_HOME
                 elif 'away' in des:
-                    self._attr_state = STATE_ALARM_ARMED_AWAY
+                    self._attr_state = AlarmControlPanelState.ARMED_AWAY
                 elif 'sleep' in des:
-                    self._attr_state = STATE_ALARM_ARMED_NIGHT
+                    self._attr_state = AlarmControlPanelState.ARMED_NIGHT
         if self._is_mgl03:
             val = self._state_attrs.get('arming.alarm')
             if val:
-                self._attr_state = STATE_ALARM_TRIGGERED
+                self._attr_state = AlarmControlPanelState.TRIGGERED
         return self._attr_state
 
     def set_arm_mode(self, mode):

--- a/custom_components/xiaomi_miot/core/const.py
+++ b/custom_components/xiaomi_miot/core/const.py
@@ -82,3 +82,21 @@ try:
     from homeassistant.core_config import DATA_CUSTOMIZE
 except (ModuleNotFoundError, ImportError):
     from homeassistant.helpers.entity import DATA_CUSTOMIZE
+
+try:
+    # hass 2024.11
+    from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+except (ModuleNotFoundError, ImportError):
+    class AlarmControlPanelState(StrEnum):
+        """Alarm control panel entity states."""
+
+        DISARMED = "disarmed"
+        ARMED_HOME = "armed_home"
+        ARMED_AWAY = "armed_away"
+        ARMED_NIGHT = "armed_night"
+        ARMED_VACATION = "armed_vacation"
+        ARMED_CUSTOM_BYPASS = "armed_custom_bypass"
+        PENDING = "pending"
+        ARMING = "arming"
+        DISARMING = "disarming"
+        TRIGGERED = "triggered"


### PR DESCRIPTION
Fix for warnings on deprecated constants in HA 2024.11 in a backward compatible way (it's the same way you used for the `CameraState` enum in 2024.10)

Alternative to #1935 which needs HA 2024.11 as a minimum.

Fixes #1913 
