### PR TITLE
Fix water level for zhimi.humidifier.ca4

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1856,7 +1856,7 @@ DEVICE_CUSTOMIZES = {
         'brightness_for_off': 2,
     },
     'zhimi.humidifier.ca4:water_level': {
-        'value_ratio': 100 / 120
+        'value_ratio': 100 / 120,
     },
     'zhimi.humidifier.cb1:water_level': {
         'state_class': 'measurement',

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1855,12 +1855,12 @@ DEVICE_CUSTOMIZES = {
         'brightness_for_on': 0,
         'brightness_for_off': 2,
     },
+    'zhimi.humidifier.ca4:water_level': {
+        'value_ratio': 100 / 120
+    },
     'zhimi.humidifier.cb1:water_level': {
         'state_class': 'measurement',
         'unit_of_measurement': '%',
-    },
-    'zhimi.humidifier.ca4:water_level': {
-        'value_ratio': 100 / 120
     },
     'zhimi.humidifier.*': {
         'sensor_properties': 'water_level,actual_speed',

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1859,6 +1859,9 @@ DEVICE_CUSTOMIZES = {
         'state_class': 'measurement',
         'unit_of_measurement': '%',
     },
+    'zhimi.humidifier.ca4:water_level': {
+        'value_ratio': 100/128
+    },
     'zhimi.humidifier.*': {
         'sensor_properties': 'water_level,actual_speed',
         'switch_properties': 'alarm,other.clean,humidifier.dry',

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1860,7 +1860,7 @@ DEVICE_CUSTOMIZES = {
         'unit_of_measurement': '%',
     },
     'zhimi.humidifier.ca4:water_level': {
-        'value_ratio': 100/128
+        'value_ratio': 100 / 120
     },
     'zhimi.humidifier.*': {
         'sensor_properties': 'water_level,actual_speed',

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1736,7 +1736,7 @@
         {
           "iid": 7,
           "unit": "percentage",
-          "value-range": [0, 100, 1]
+          "value-range": [0, 128, 1]
         }
       ]
     },


### PR DESCRIPTION
This humidifier reports water level values in range 0-128 (see [spec](https://home.miot-spec.com/spec/zhimi.humidifier.ca4)). When the water tank level above 100 units, the value is rejected and the water level becomes unavailable. This PR fixes that issue.

The Mi Home app reports all values above 120 units as 100%, so I used this as the value ratio