### PR TITLE
Update miio2miot_specs.py about zhimi.aircondition.v1

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -2596,18 +2596,17 @@ MIIO_TO_MIOT_SPECS = {
             }},
             'prop.3.2': {'prop': 'horizon_swing', 'setter': 'set_horizon', 'format': 'onoff'},
             'prop.3.3': {'prop': 'vertical_swing', 'setter': 'set_vertical', 'format': 'onoff'},
-            'prop.3.4': {'prop': 'vertical_rt', 'setter': 'set_ver_pos'},  # 该Setter不适用本空调
+            'prop.3.4': {'prop': 'vertical_rt', 'setter': 'set_ver_pos'},
             'prop.4.1': {'prop': 'temp_dec', 'template': '{{ value|default(0,true)/10.0 }}'},
             'prop.4.2': {'prop': 'temp_dec', 'template': '{{ value|default(0,true)/10.0 }}'},
             'prop.4.3': {'prop': 'humidity'},
             'prop.4.4': {'prop': 'humidity'},
             'prop.5.1': {
-                'prop': 'volume', # 修改了适用本空调的Attributes
-                'setter': 'set_volume', # 修改了适用本空调的Setter
-                'template': '{{ (value/10)|int }}', # miio 取回的值为设定值的10倍，即0-70，步长10
-                'set_template': '{{ value|int }}', # miio 设定的值为0-7的整数，步长1
+                'prop': 'volume',
+                'setter': 'set_volume',
+                'set_template': '{{ (value/10)|int }}',
             },
-            'prop.6.1': {'prop': 'lcd_level', 'setter': 'set_lcd_level'}, # 修改了适用本空调的Attributes和Setter，miio 设定的值为0-7的整数，步长1
+            'prop.6.1': {'prop': 'lcd_level', 'setter': 'set_lcd_level'},
         },
     },
 

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -2596,18 +2596,18 @@ MIIO_TO_MIOT_SPECS = {
             }},
             'prop.3.2': {'prop': 'horizon_swing', 'setter': 'set_horizon', 'format': 'onoff'},
             'prop.3.3': {'prop': 'vertical_swing', 'setter': 'set_vertical', 'format': 'onoff'},
-            'prop.3.4': {'prop': 'vertical_rt', 'setter': 'set_ver_pos'},
+            'prop.3.4': {'prop': 'vertical_rt', 'setter': 'set_ver_pos'},  # 该Setter不适用本空调
             'prop.4.1': {'prop': 'temp_dec', 'template': '{{ value|default(0,true)/10.0 }}'},
             'prop.4.2': {'prop': 'temp_dec', 'template': '{{ value|default(0,true)/10.0 }}'},
             'prop.4.3': {'prop': 'humidity'},
             'prop.4.4': {'prop': 'humidity'},
             'prop.5.1': {
-                'prop': 'volume_level',
-                'setter': 'set_volume_sw',
-                'template': '{{ (value*14.286)|int }}',
-                'set_template': '{{ [(value/14.285)|int] }}',
+                'prop': 'volume', # 修改了适用本空调的Attributes
+                'setter': 'set_volume', # 修改了适用本空调的Setter
+                'template': '{{ (value/10)|int }}', # miio 取回的值为设定值的10倍，即0-70，步长10
+                'set_template': '{{ value|int }}', # miio 设定的值为0-7的整数，步长1
             },
-            'prop.6.1': {'prop': 'lcd_level', 'setter': 'set_lcd'},
+            'prop.6.1': {'prop': 'lcd_level', 'setter': 'set_lcd_level'}, # 修改了适用本空调的Attributes和Setter，miio 设定的值为0-7的整数，步长1
         },
     },
 

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1653,6 +1653,16 @@
           ]
         }
       ]
+    },
+    {
+      "iid": 5,
+      "properties": [
+        {
+          "iid": 1,
+          "access": ["read", "write"],
+          "value-range": [0, 70, 10]
+        }
+      ]
     }
   ],
   "zhimi.airfresh.va4":[


### PR DESCRIPTION
1. 主要修改了提示音和显示屏亮度的Setter，以适配这个型号特殊的空调
2. 扫风角度实体没有如期生成，而且'set_ver_pos'这个Setter也不适用该空调，暂时没有找到正确的Setter

还有一些其他问题，见issue  https://github.com/al-one/hass-xiaomi-miot/issues/2107 ，希望大佬抽出时间，我们一起把这个空调完美搞定🤝