### PR TITLE
修复Yeelight屏幕挂灯Pro背光灯

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -2291,6 +2291,19 @@ MIIO_TO_MIOT_SPECS = {
     'yeelink.light.lamp7': 'yeelink.light.ceiling16',
     'yeelink.light.lamp9': 'yeelink.light.ceiling6',
     'yeelink.light.lamp10': 'yeelink.light.bslamp3',
+    'yeelink.light.lamp15': {
+        'miio_specs': {
+            'prop.2.1': {'prop': 'power', 'setter': True, 'format': 'onoff'},
+            'prop.2.2': {'prop': 'bright', 'setter': True},
+            'prop.2.3': {'prop': 'ct', 'setter': 'set_ct_abx', 'set_template': '{{ [value,"smooth",500] }}'},
+            'prop.2.5': {'prop': 'color_mode'},
+            'prop.3.6': {'prop': 'bg_power', 'setter': 'bg_set_power', 'format': 'onoff'},
+            'prop.200.201': {'prop': 'bg_power', 'setter': 'bg_set_power', 'format': 'onoff'},
+            'prop.200.202': {'prop': 'bg_bright', 'setter': 'bg_set_bright'},
+            'prop.200.203': {'prop': 'bg_ct', 'setter': 'bg_set_ct_abx', 'set_template': '{{ [value,"smooth",500] }}'},
+            'prop.200.204': {'prop': 'bg_rgb', 'setter': 'bg_set_rgb'},
+        },
+    },
     'yeelink.light.mono1': {
         'miio_specs': {
             'prop.2.1': {'prop': 'power', 'setter': True, 'format': 'onoff'},

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1585,6 +1585,7 @@
       ]
     }
   ],
+
   "yunmi.waterpuri.lx5": [
     {
       "iid": 2,

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1552,7 +1552,39 @@
   ],
   "yeelink.light.panel1": "yeelink.light.ceiling1",
   "yeelink.light.panel3": "yeelink.light.ceiling1",
-
+  "yeelink.light.lamp15": [
+    {
+      "iid": 200,
+      "type": "urn:miot-spec-v2:service:ambient-light",
+      "description": "Ambient Light",
+      "properties": [
+        {
+          "iid": 201,
+          "type": "urn:miot-spec-v2:property:on",
+          "description": "Switch Status",
+          "format": "bool",
+          "access": ["read", "write"]
+        },
+        {
+          "iid": 202,
+          "type": "urn:miot-spec-v2:property:brightness",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "unit": "percentage",
+          "value-range": [1, 100, 1]
+        },
+        {
+          "iid": 204,
+          "type": "urn:miot-spec-v2:property:color",
+          "description": "Color",
+          "format": "uint32",
+          "access": ["read", "write"],
+          "unit": "rgb",
+          "value-range": [1, 16777215, 1]
+        }
+      ]
+    }
+  ],
   "yunmi.waterpuri.lx5": [
     {
       "iid": 2,


### PR DESCRIPTION
型号：**Yeelight屏幕挂灯Pro**（yeelight.light.lamp15），由前色温灯和后颜色灯组成。
调整前：默认只有一个前色温灯，颜色灯只有一个开关，无法调整其颜色。
调整后：参考yeelight官方插件，设为两个实体，增加一个颜色灯实体，可正常调整颜色。
待优化：色温灯应屏蔽颜色调整的选项，背灯开关可删除。

![Picsew_20241225下午104852](https://github.com/user-attachments/assets/c3d3c7f2-c6eb-4e62-89da-3d129daedb9c)
