### PR TITLE
Add Air Purifier 4 Lite (zhimi.airp.rmb1) support

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2040,6 +2040,11 @@ DEVICE_CUSTOMIZES = {
     'zhimi.airp.meb1:pm10_density': {
         'unit_of_measurement': 'µg/m³',
     },
+    'zhimi.airp.rmb1': {
+        'switch_properties': 'alarm',
+        'select_properties': 'brightness',
+        'number_properties': 'favorite_level',
+    },
     'zhimi.airp.sa4': {
         'switch_properties': 'alarm',
         'number_properties': 'air_purifier_favorite.fan_level,aqi_updata_heartbeat',


### PR DESCRIPTION
Implemented Air Purifier 4 Lite properties in `device_customizes.py`. 

Change allows the user to switch alarm modes, set screen brightness and set custom speed through `favorite_level`.

As of now the field name in HA is "Xiaomi Air Purifier custom-service favorite-level" because it's a custom service option as listed in: https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-rmb1:1 

If there's a way to add custom name I can do it.