### PR TITLE
add sensor with 'fault' property to  dmaker.derh.22ht and dmaker.derh.50l

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -585,6 +585,12 @@ DEVICE_CUSTOMIZES = {
         'switch_properties': 'air_purifier.on,screen.on,alarm',
         'number_properties': 'favorite_speed,moto_hz',
     },
+    'dmaker.derh.22ht': {
+        'sensor_properties': 'failure',
+    },
+    'dmaker.derh.50l': {
+        'sensor_properties': 'failure',
+    },
     'dmaker.fan.1e': {
         'button_actions': 'toggle_mode,loop_gear',
         'number_properties': 'off_delay_time,speed_level',


### PR DESCRIPTION
fault property can tell if compressor is at fault
  or if water tank is full.
reporting about water tank in dehumifier being full is
  almost mandatory when you have smart dehumidifier.