### PR TITLE
fix opple.light.yrtd

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1327,6 +1327,9 @@ DEVICE_CUSTOMIZES = {
         'switch_properties': 'night_light,time_display,wake_up_at_night,voice',
         'select_properties': 'study_time',
         'number_properties': 'love_bright,love_color',
+        'chunk_coordinators': [
+            {'interval': 10, 'props': 'on,mode'},
+        ],
     },
     'ows.towel_w.mj1x0': {
         'sensor_properties': 'temperature',


### PR DESCRIPTION
fix #2300 
opple.light.yrtd 使用light设备默认的chunk_coordinators查询属性会导致设备死机，更新为只查询on,mode, 测试正常
