### PR TITLE
Make "Got miio props for miot" print in debug

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot.py
+++ b/custom_components/xiaomi_miot/core/miio2miot.py
@@ -105,7 +105,7 @@ class Miio2MiotHelper:
             if isinstance(pdt, dict):
                 dic.update(pdt)
         self.miio_props_values = dic
-        _LOGGER.info('%s: Got miio props for miot: %s', self.model, dic)
+        _LOGGER.debug('%s: Got miio props for miot: %s', self.model, dic)
         return dic
 
     async def async_get_miot_props(self, *args, **kwargs):


### PR DESCRIPTION
This spams my log:
```
2025-03-02 16:34:30.489 INFO (SyncWorker_2) [custom_components.xiaomi_miot.core.miio2miot] yeelink.light.bslamp1: Got miio props for miot: {'power': 'off', 'bright': '87', 'rgb': '16750592', 'ct': '1700', 'color_mode': '1', 'nl_br': '0', 'delayoff': '0', 'sat': '100'} 
2025-03-02 16:34:30.490 INFO (MainThread) [custom_components.xiaomi_miot.core.device.yeelink.light.bslamp1] Device updated: {'light.light.on': False, 'light.brightness': 221.85, 'light.color': (255, 152, 0), 'light.color_temperature': 1700, 'light.mode': 'Color', 'only_info': False} 
2025-03-02 16:34:40.512 INFO (SyncWorker_4) [custom_components.xiaomi_miot.core.miio2miot] yeelink.light.bslamp1: Got miio props for miot: {'power': 'off', 'bright': '87', 'rgb': '16750592', 'ct': '1700', 'color_mode': '1', 'nl_br': '0', 'delayoff': '0', 'sat': '100'} 
2025-03-02 16:34:40.512 INFO (MainThread) [custom_components.xiaomi_miot.core.device.yeelink.light.bslamp1] Device updated: {'light.light.on': False, 'light.brightness': 221.85, 'light.color': (255, 152, 0), 'light.color_temperature': 1700, 'light.mode': 'Color', 'only_info': False} 
```