### PR TITLE
fix humidifier mode setting when power is off

### DIFF
--- a/custom_components/xiaomi_miot/humidifier.py
+++ b/custom_components/xiaomi_miot/humidifier.py
@@ -119,6 +119,8 @@ class HumidifierEntity(XEntity, BaseEntity):
             return
         if not self._conv_mode:
             return
+        if mode != MODE_OFF and not self._attr_is_on:
+            await self.async_turn_on()
         await self.device.async_write({self._conv_mode.full_name: mode})
 
     async def async_set_humidity(self, humidity: int):

--- a/custom_components/xiaomi_miot/humidifier.py
+++ b/custom_components/xiaomi_miot/humidifier.py
@@ -117,15 +117,21 @@ class HumidifierEntity(XEntity, BaseEntity):
         if mode == MODE_OFF:
             await self.async_turn_off()
             return
-        if not self._conv_mode:
-            return
-        if mode != MODE_OFF and not self._attr_is_on:
-            await self.async_turn_on()
-        await self.device.async_write({self._conv_mode.full_name: mode})
+        data = {}
+        if not self._attr_is_on and self._conv_power:
+            data[self._conv_power.full_name] = True
+        if self._conv_mode:
+            data[self._conv_mode.full_name] = mode
+        if data:
+            await self.device.async_write(data)
 
     async def async_set_humidity(self, humidity: int):
         if not self._conv_target_humidity:
             return
+        data = {}
+        if not self._attr_is_on and self._conv_power:
+            data[self._conv_power.full_name] = True
+
         prop = getattr(self._conv_target_humidity, 'prop', None)
         if self._target_humidity_step:
             humidity = round(humidity / self._target_humidity_step) * self._target_humidity_step
@@ -136,6 +142,8 @@ class HumidifierEntity(XEntity, BaseEntity):
             humidity = vls[idx - 1] if idx > 0 else vls[0]
         if self._target_humidity_ratio:
             humidity = round(humidity / self._target_humidity_ratio)
-        await self.device.async_write({self._conv_target_humidity.full_name: humidity})
+
+        data[self._conv_target_humidity.full_name] = humidity
+        await self.device.async_write(data)
 
 XEntity.CLS[ENTITY_DOMAIN] = HumidifierEntity


### PR DESCRIPTION
Beginning with v1.0.14, changing the mode of a humidifier from "off" to other modes doesn't work.

It seems that this functionality (introduced in https://github.com/al-one/hass-xiaomi-miot/pull/1761) is lost [during refactoring](https://github.com/al-one/hass-xiaomi-miot/commit/705a9e0b8c4d69172928ca2126c872e054bda80c).

This PR adds it back.

Tested locally with my `xiaomi.humidifier.p1200`.