### PR TITLE
`zhimi.humidifier.ca7`: proper water_level handling 

### DIFF
--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -1888,6 +1888,23 @@
       ]
     }
   ],
+  "zhimi.humidifier.ca7": [
+    {
+      "iid": 2,
+      "properties": [
+        {
+          "iid": 6,
+          "unit": "",
+          "value-list": [
+            {"value": 0, "description": "empty"},
+            {"value": 1, "description": "normal"},
+            {"value": 2, "description": "full"}
+          ],
+          "value-range": []
+        }
+      ]
+    }
+  ],
   "zhimi.humidifier.cb1": "zhimi.humidifier.ca1",
 
   "xiaomi.heater.ma8": [


### PR DESCRIPTION
`zhimi.humidifier.ca7`: proper water_level handling (the same as for `zhimi.humidifier.ca6`).

Original spec for `zhimi.humidifier.ca7` can be found here: https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:humidifier:0000A00E:zhimi-ca7:1:0000D061

I thought I can just reuse config for `zhimi.humidifier.ca6` - as simple as `"zhimi.humidifier.ca7": "zhimi.humidifier.ca6"`, but unfortunately water_level iids are diferent (7 for ca6 and 6 for ca7).