### PR TITLE
👕 fix mrbond.airer.m3* and hyd.airer.h* (closes #870, #2554)

### DIFF
--- a/custom_components/xiaomi_miot/core/converters.py
+++ b/custom_components/xiaomi_miot/core/converters.py
@@ -17,7 +17,7 @@ class BaseConv:
 
     def __post_init__(self):
         if self.attrs is None:
-            self.attrs = set()
+            self.attrs = []
         if self.option is None:
             self.option = {}
 

--- a/custom_components/xiaomi_miot/core/converters.py
+++ b/custom_components/xiaomi_miot/core/converters.py
@@ -214,22 +214,39 @@ class MiotBrightnessConv(MiotPropConv):
 @dataclass
 class MiotColorTempConv(MiotPropConv):
     def decode(self, device: 'Device', payload: dict, value: int):
-        if self.prop.unit not in ['kelvin']:
+        if self.prop.unit == 'percentage':
+            if not value:
+                return
+            value = self.percentage_to_kelvin(value)
+        elif self.prop.unit != 'kelvin':
             if not value:
                 return
             value = round(1000000.0 / value)
         super().decode(device, payload, value)
 
     def encode(self, device: 'Device', payload: dict, value: int):
-        if self.prop.unit not in ['kelvin']:
+        if self.prop.unit == 'percentage':
+            if not value:
+                return
+            value = self.kelvin_to_percentage(value)
+        elif self.prop.unit != 'kelvin':
             if not value:
                 return
             value = round(1000000.0 / value)
+
         if value < self.prop.range_min():
             value = self.prop.range_min()
         if value > self.prop.range_max():
             value = self.prop.range_max()
         super().encode(device, payload, value)
+
+    @staticmethod
+    def percentage_to_kelvin(p: int) -> int:
+        return 6500 - p * 40
+
+    @staticmethod
+    def kelvin_to_percentage(k: int) -> int:
+        return round((6500 - k) / 40)
 
 @dataclass
 class MiotRgbColorConv(MiotPropConv):

--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -425,8 +425,8 @@ class Device(CustomConfigHelper):
                             d = pc.get('domain', None)
                             ac = c(attr, domain=d, prop=prop, desc=pc.get('desc'))
                             self.add_converter(ac)
-                            if conv:
-                                conv.attrs.add(ac.full_name)
+                            if conv and ac.full_name not in conv.attrs:
+                                conv.attrs.append(ac.full_name)
 
         for d in [
             'button', 'sensor', 'binary_sensor', 'switch', 'number', 'select', 'text',

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1344,6 +1344,18 @@ DEVICE_CUSTOMIZES = {
     'mrbond.airer.m1s': {
         'miot_type': 'urn:miot-spec-v2:device:airer:0000A00D:mrbond-m1pro:1',
     },
+    'mrbond.airer.m31a': {
+        'cover_position_mapping': None,
+        'disable_target_position': True,
+        'number_properties': 'target_position',
+        'append_converters': [
+            {
+                'class': MiotCoverConv,
+                'services': ['airer'],
+                'converters': [{'props': ['prop.2.10']}],
+            }
+        ],
+    },
     'mrbond.airer.m53pro': {
         'sensor_properties': 'fault,left_time',
         'select_properties': 'dryer,drying_level',
@@ -1351,6 +1363,7 @@ DEVICE_CUSTOMIZES = {
         'chunk_properties': 1,
     },
     'mrbond.airer.*': {
+        'deviated_position': 0,
         'parallel_updates': 1,
     },
     'msj.f_washer.m2': {
@@ -1990,7 +2003,7 @@ DEVICE_CUSTOMIZES = {
         'sensor_properties': 'status,fault,left_time,tank_status,timeout_time,boiling_point',
         'switch_properties': 'alarm,pot_lift_memory,auto_keep_warm,auto_screen_on',
         'select_properties': 'cook_mode',
-        'number_properties': 'keep_warm_time,target_temperature,working_level,target_time', 
+        'number_properties': 'keep_warm_time,target_temperature,working_level,target_time',
     },
     'xiaomi.health_pot.p1': {
         'select_actions': 'start_cook',
@@ -2973,12 +2986,25 @@ DEVICE_CUSTOMIZES = {
 
 }
 
-DEVICE_CUSTOMIZES.update({
-    '*.airp.*': DEVICE_CUSTOMIZES.get('*.airpurifier.*') or {},
-    '*.door.*': DEVICE_CUSTOMIZES.get('*.lock.*') or {},
-    '*.dryer.*': DEVICE_CUSTOMIZES.get('*.dry.*') or {},
-    '*.pre_cooker.*': DEVICE_CUSTOMIZES.get('*.cooker.*') or {},
-})
+DEVICE_CUSTOMIZES.update({item: DEVICE_CUSTOMIZES[src] for src, dest in {
+    'mrbond.airer.m31a': [
+        'hyd.airer.h51a',
+        'hyd.airer.h51c',
+        'hyd.airer.hx1',
+        'hyd.airer.hx2',
+        'hyd.airer.hx3',
+        'mrbond.airer.m31a2',
+        'mrbond.airer.m31c',
+        'mrbond.airer.m31c2',
+        'mrbond.airer.m33a',
+        'mrbond.airer.m33c',
+    ],
+
+    '*.airpurifier.*': ['*.airp.*'],
+    '*.lock.*': ['*.door.*'],
+    '*.dry.*': ['*.dryer.*'],
+    '*.cooker.*': ['*.pre_cooker.*'],
+}.items() for item in dest})
 
 
 GLOBAL_CONVERTERS = [

--- a/custom_components/xiaomi_miot/light.py
+++ b/custom_components/xiaomi_miot/light.py
@@ -198,21 +198,12 @@ class MiotLightEntity(MiotToggleEntity, BaseEntity):
 
         self._attr_color_mode = None
         self._attr_supported_color_modes = set()
-        self._is_percentage_color_temp = None
         if self._prop_color_temp:
             self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
-            self._is_percentage_color_temp = self._prop_color_temp.unit in ['percentage', '%']
-            if self._is_percentage_color_temp:
-                # issues/870
-                self._vars['color_temp_min'] = self._prop_color_temp.range_min()
-                self._vars['color_temp_max'] = self._prop_color_temp.range_max()
-                self._attr_min_mireds = self._vars['color_temp_min']
-                self._attr_max_mireds = self._vars['color_temp_max']
-            else:
-                self._vars['color_temp_min'] = self._prop_color_temp.range_min() or 3000
-                self._vars['color_temp_max'] = self._prop_color_temp.range_max() or 5700
-                self._attr_min_mireds = self.translate_mired(self._vars['color_temp_max'])
-                self._attr_max_mireds = self.translate_mired(self._vars['color_temp_min'])
+            self._vars['color_temp_min'] = self._prop_color_temp.range_min() or 3000
+            self._vars['color_temp_max'] = self._prop_color_temp.range_max() or 5700
+            self._attr_min_mireds = self.translate_mired(self._vars['color_temp_max'])
+            self._attr_max_mireds = self.translate_mired(self._vars['color_temp_min'])
             self._vars['color_temp_sum'] = self._vars['color_temp_min'] + self._vars['color_temp_max']
             self._vars['mireds_sum'] = self._attr_min_mireds + self._attr_max_mireds
         if self._prop_color:
@@ -386,9 +377,6 @@ class MiotLightEntity(MiotToggleEntity, BaseEntity):
         return ColorMode.UNKNOWN
 
     def translate_mired(self, num):
-        if self._is_percentage_color_temp:
-            # issues/870
-            return num
         try:
             return round(1000000 / num)
         except TypeError:


### PR DESCRIPTION
本 PR 对邦先生 [`mrbond.airer.m3*`](https://home.miot-spec.com/spec/mrbond.airer.m33c) 系列晾衣机产品进行优化适配。

首先抛开代码实现，记录和讨论下晾衣架设备本身的行为。同为好易点设计生产的晾衣机产品，M31/M33 系列与之前已适配的邦先生 [`mrbond.airer.m1t*`](https://home.miot-spec.com/spec/mrbond.airer.m1tpro) 系列，及米家智能晾衣机 [`hyd.airer.*`](https://home.miot-spec.com/spec/hyd.airer.lyjpro) 系列在 MIoT Property 设计上有强烈的共性特征：

|SIID|PIID|name|desc|
|----|----|----|----|
|  2 |  4 | status           | 0 上限位停止, 1 上升中, 2 下降中, 3 暂停, 4 下限位停止
|  2 |  3 | current-position | 当前位置（上限、中间、下限，范围0-2）
|  2 | 10 | current-position | 当前位置（百分比：上限位0至下限位100）
|  2 | 11 | current-position | 运动速度（百分比里程/10秒）
|  2 | 13 | target-position  | 指定下限位最大值（10-100）
|  2 |8  9| target-position  | 指定上限位最小值（0-49）和下限位最大值（51-100）

1. 均有多个相同名称、不同编号、不同含义的 `current-position`
- `prop.2.10` 是当前百分比位置，应当被优先选用。在某些机型上编号是 `prop.2.11`
- `prop.2.3` 为上、中、下三值枚举，仅当设备不支持获取百分比位置时，才用于映射到 0, 50, 100 兜底
- `prop.2.11` 在部分机器上是当前运动速度，实测我的晾衣架下降时是 50-51，空载上升时是 47-49，挂着多件衣服上升时是42-43，或许可以用于粗略判断晾衣架是不是空的。
2. 均有设置下限位的 `target-position`，部分机型拥有设置上限位的 `target-position`。该属性写入后只会设置未来运动的限位，不会触发运动。想要完美适配的话，`target-position` 的正确功能是用来覆盖 `current-position` 的最大（最小）值 `prop.value_range`。简单起见，可暂不考虑这层关系，将 `target-position` 映射为独立 `number` 实体。

---

之后讨论代码当前的实现方式和问题。
`GLOBAL_CONVERTERS` 对于 `airer` 服务的默认处理逻辑中会自动获取上面讨论的两个属性：

1. 关于 `current-position`:
   1. 对于多个重名的 `current-position` 属性，PIID 最小的一条（三值枚举 `prop.2.3`）会占据主名称，被获取到
   2. 由于目前 `{class}_properties` 和 `append_converters` 仅提供在 `GLOBAL_CONVERTERS` 原有属性集基础上添加更多属性的能力，缺少对 `GLOBAL_CONVERTERS` 原有属性进行删除、替换的入口。因此，无法直接将 `current-position` 的取值来源从枚举 `prop.2.3` 替换为百分比 `prop.2.10` 或 `prop.2.11`。
   3. 近期实现的补丁 709f9ac 通过 `append_converters` 将 `prop.2.11` 追加到了 `prop.2.3` 的旁边，没有删除无用的 `prop.2.3`。本次 PR 沿用了这一思路。
   4. 该补丁实现有时是可用的，其能正常工作的机理是，在 `CoverEntity.on_init` 循环处理属性的过程中，后面的 `current-position` 会覆盖前面的同名属性：
https://github.com/al-one/hass-xiaomi-miot/blob/bd34039cc3b7960d7e767c6e75310aee6b0f7090/custom_components/xiaomi_miot/cover.py#L85-L106
   5. 该补丁实现有时又是不可用的，其不能正常工作的原因是，`self.conv.attrs` 的类型是无序的 `set`，不能保证后通过 `append_converters` 追加的元素一定在 `for` 循环中排在后面。由于这个 `for` 循环只在 `on_init` 时调用一次，此缺陷只要复现，则 HA 重启前会一直持续；只要问题未发生，在下次 HA 重启前都不会触发。本次 PR 中将其类型修正为了有序的 `list` 来解决这一缺陷。
2. 关于 `target-position`
   1. 在支持「运动到百分比位置」能力的晾衣机上，和上文讨论情况一样，无法直接将取值来源从 `target-position` 置换为 `set-position` 等其他属性。目前的绕过方式以及非必现缺陷和上文也一模一样
   2. 这里存在两个名称近似的设置项 `target_position_props` 和 `target_position_properties`，我阅读代码后，没理解近期才新增的前者 543b9c6e #2327 解决了什么后者无法应对的问题，还望作者赐教…
   3. 对于缺少「运动到百分比位置」能力的晾衣机， 709f9ac 增加了 `disable_target_position` 设置项，虽然不能消除无用的通信开销，但能解决误判实体能力的情况，本 PR 中复用。