### PR TITLE
🔋 add energy for xiaomi.aircondition.mc8

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1811,6 +1811,11 @@ DEVICE_CUSTOMIZES = {
     'xiaomi.aircondition.ma4': {
         'miot_type': 'urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-ma4:2',
     },
+    'xiaomi.aircondition.mc8': {
+        'stat_power_cost_type': 'total_day',
+        'stat_power_cost_key': '8.1',
+        'sensor_attributes': 'power_cost_today,power_cost_month',
+    },
     'xiaomi.aircondition.mc9': {
         'exclude_miot_services': 'machine_state,flag_bit',
         'exclude_miot_properties': 'enhance.timer',


### PR DESCRIPTION
为 [`xiaomi.aircondition.mc8`](https://home.miot-spec.com/spec/xiaomi.aircondition.mc8) 增加耗电量统计