### PR TITLE
❄️ fix climate mode state update for bhf_light

### DIFF
--- a/custom_components/xiaomi_miot/climate.py
+++ b/custom_components/xiaomi_miot/climate.py
@@ -236,7 +236,7 @@ class ClimateEntity(XEntity, BaseClimateEntity):
             val = self._conv_mode.value_from_dict(data)
             if val in self._attr_preset_modes:
                 self._attr_preset_mode = val
-            elif val is not None:
+            if val is not None:
                 for mk, mv in self._hvac_modes.items():
                     if val == mv.get('description'):
                         self._attr_hvac_mode = mk


### PR DESCRIPTION
  ## 改动说明
  - 改善Yeelight浴霸类设备的状态刷新
  - 修复 climate 状态解析中 preset 与 hvac 模式冲突导致的状态不同步
  - 当设备上报的 mode 同时属于 preset 与 hvac 描述时，确保 hvac 状态也会更新

  ## 影响范围
  - 仅影响使用 mode 属性且描述同时出现在 preset/hvac 的设备（应该只影响 HVACMode.OFF 对应的描述，其他都已经在原有代码的初始化阶段被排除掉了）。

  ## 分析和思路
  - 初始化时，mode 枚举的描述会填入 preset_modes。
  - _hvac_modes 会根据描述匹配 HVAC 模式，并把对应描述从 preset_modes 移除；后续更新中增加了条件，OFF 的描述被保留在 preset_modes（if mk != HVACMode.OFF）。
  - set_state() 里 preset 优先级高于 hvac，且用 elif 短路。
  - 当设备上报 Idle（OFF 的描述）时，会被当成 preset，导致 hvac_mode 不更新。
  - 影响范围仅限“描述同时存在于 preset + hvac”这一类设备，核心是 OFF 描述被保留在 preset 的场景。
  - 改 elif -> if 让 hvac 模式解析不会被 preset 短路，OFF 状态可以正确刷新。

  ## 测试
  - 本地环境下 yeelink.bhf_light_vN 设备各模式切换和更新正常，但是我没有使用其他设备比如小米的空调，所以不确定是否会产生影响。

---
## Change Description
- Improve state refresh for Yeelight bathroom heater devices
- Fix state synchronization issue caused by conflicts between preset and hvac mode in climate state parsing
- Ensure hvac state is also updated when the device-reported mode belongs to both preset and hvac descriptions

## Scope of Impact
- Only affects devices using the mode attribute where descriptions appear in both preset/hvac (should only impact descriptions corresponding to HVACMode.OFF, as others are already excluded during initialization in the original code).

## Analysis and Approach
- During initialization, mode enum descriptions are populated into preset_modes.
- _hvac_modes matches descriptions to HVAC modes and removes corresponding descriptions from preset_modes; Subsequent updates added a condition that preserves OFF descriptions in preset_modes (if mk != HVACMode.OFF).
- In set_state(), preset has higher priority than hvac and uses elif for short-circuit evaluation.
- When the device reports "Idle" (OFF description), it's treated as a preset, preventing hvac_mode from updating.
- Impact is limited to devices where "descriptions exist in both preset + hvac", primarily scenarios where OFF descriptions are retained in presets.
- Changed elif -> if to prevent hvac mode parsing from being short-circuited by preset, allowing OFF state to refresh correctly.

## Testing
- In local environment, yeelink.bhf_light_vN device mode switching and updates work normally, but I haven't tested with other devices such as Xiaomi air conditioners, so I'm uncertain about potential impacts.

## Related Issues
Fixes #2684  #2688  