### PR TITLE
fix(entity): use slugify for entity id generation

### DIFF
--- a/custom_components/xiaomi_miot/remote.py
+++ b/custom_components/xiaomi_miot/remote.py
@@ -13,6 +13,7 @@ from homeassistant.components.remote import (
     RemoteEntity,
     RemoteEntityFeature,
 )
+from homeassistant import core as hass_core
 
 from . import (
     DOMAIN,
@@ -20,6 +21,7 @@ from . import (
     XIAOMI_CONFIG_SCHEMA as PLATFORM_SCHEMA,  # noqa: F401
     HassEntry,
     MiotEntity,
+    slugify_object_id,
     async_setup_config_entry,
     bind_services_to_entries,
 )
@@ -87,6 +89,9 @@ class MiotRemoteEntity(MiotEntity, RemoteEntity):
         self._attr_should_poll = False
         self._supported_features = RemoteEntityFeature.LEARN_COMMAND
         self._translations = get_translations('ir_devices')
+        if self.entity_id:
+            obj = hass_core.split_entity_id(self.entity_id)[1]
+            self.entity_id = f'{ENTITY_DOMAIN}.{slugify_object_id(obj)}'
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
@@ -124,7 +129,7 @@ class MiotRemoteEntity(MiotEntity, RemoteEntity):
                         ols.append(nam)
                     self._subs[ird] = SelectSubEntity(self, ird, option={
                         'name': d.get('name'),
-                        'entity_id': f'remote_{ird}'.replace('.', '_'),
+                        'entity_id': slugify_object_id(f'remote_{ird}'),
                         'options': ols,
                         'async_select_option': self.async_press_ir_key,
                     })

--- a/custom_components/xiaomi_miot/select.py
+++ b/custom_components/xiaomi_miot/select.py
@@ -74,7 +74,7 @@ XEntity.CLS[ENTITY_DOMAIN] = SelectEntity
 
 class SelectSubEntity(BaseEntity, BaseSubEntity):
     def __init__(self, parent, attr, option=None):
-        BaseSubEntity.__init__(self, parent, attr, option)
+        BaseSubEntity.__init__(self, parent, attr, option, domain=ENTITY_DOMAIN)
         self._available = True
         self._attr_current_option = None
         self._attr_options = self._option.get('options') or []


### PR DESCRIPTION
Introduce slugify_object_id helper to ensure all generated entity IDs conform to Home Assistant standards. This replaces manual regex replacements with a more robust slugification process across MiotEntity, BaseSubEntity, and remote entities to prevent potential naming issues.


日志记录器: homeassistant.components.remote
来源: helpers/entity_platform.py:826
集成: 遥控 (文档, 问题)
首次出现: 2026年1月31日 22:00:38 (2 次出现)
上次记录: 2026年1月31日 22:00:38
Error adding entity xiaomi_miot.xiaomi_l05c_0E28_wifispeaker for domain remote with platform xiaomi_miot
Error adding entity xiaomi_miot.xiaomi_oh2p_F9DD_wifispeaker for domain remote with platform xiaomi_miot
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 826, in _async_add_entity
raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
homeassistant.exceptions.HomeAssistantError: Invalid entity ID: xiaomi_miot.xiaomi_l05c_0E28_wifispeaker