### PR TITLE
Fix token retrieval issue for Yi devices with non-hexadecimal tokens

### DIFF
--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -87,22 +87,26 @@ class DeviceInfo:
 
     @property
     def token(self):
-        token = self.data.get(CONF_TOKEN) or ''
+        primary_token = self.data.get(CONF_TOKEN) or ''
         # For Yi cameras and similar devices, the top-level token may not be valid hex
         # Check if token is valid hexadecimal, otherwise try extra.token
-        if token:
+        if primary_token:
             try:
-                bytes.fromhex(token)
+                bytes.fromhex(primary_token)
+                return primary_token
             except ValueError:
-                # Top-level token is not valid hex, try extra.token
-                extra_token = self.data.get('extra', {}).get('token', '')
-                if extra_token:
-                    try:
-                        bytes.fromhex(extra_token)
-                        return extra_token
-                    except ValueError:
-                        pass
-        return token or self.miio_info.token
+                # Primary token is not valid hex, try extra.token
+                pass
+        
+        extra_token = self.data.get('extra', {}).get('token', '')
+        if extra_token:
+            try:
+                bytes.fromhex(extra_token)
+                return extra_token
+            except ValueError:
+                # Extra token is also not valid hex, fall through to miio_info.token
+                pass
+        return self.miio_info.token
 
     @cached_property
     def pid(self):


### PR DESCRIPTION
Fix below errors for Yi cameras and similar devices, the top-level token may not be valid hex, check if token is valid hexadecimal, otherwise try extra.token

```
ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Xiaomi: ******** for xiaomi_miot
 Traceback (most recent call last):
   File "/usr/src/homeassistant/homeassistant/config_entries.py", line 769, in __async_setup_with_context
     result = await component.async_setup_entry(hass, self)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/config/custom_components/xiaomi_miot/__init__.py", line 233, in async_setup_entry
     await async_setup_xiaomi_cloud(hass, config_entry)
   File "/config/custom_components/xiaomi_miot/__init__.py", line 279, in async_setup_xiaomi_cloud
     device = await entry.new_device(d)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/config/custom_components/xiaomi_miot/core/hass_entry.py", line 99, in new_device
     await device.async_init()
   File "/config/custom_components/xiaomi_miot/core/device.py", line 184, in async_init
     self.local = MiotDevice.from_device(self)
                  ~~~~~~~~~~~~~~~~~~~~~~^^^^^^
   File "/config/custom_components/xiaomi_miot/core/device.py", line 1369, in from_device
     miio = AsyncMiIO(host, token)
   File "/config/custom_components/xiaomi_miot/core/mini_miio.py", line 34, in __init__
     self.token = bytes.fromhex(token)
                  ~~~~~~~~~~~~~^^^^^^^
 ValueError: non-hexadecimal number found in fromhex() arg at position 1
```