### PR TITLE
Update README.md - Local Device Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Starting from the v0.4.4 version, the component has added support for selecting 
 - **Local**: All devices filtered by the integrated configuration will use local connection. If you check the devices that do not support miot in LAN, they will be unavailable
 - **Cloud**: All devices filtered by the integrated configuration will use cloud connection. It is recommended that miio, BLE, ZigBee devices use this mode
 
-NB: For **Local** on some devices, your Home Assistant server needs to be on the same Subnet/VLAN, or you need to NAT your Home Assistant IP to the same subnet. The devices will not respond to control requests from a different subnet. 
+**Note:** For **Local** mode, some devices require Home Assistant to be on the same subnet/VLAN. They will not respond to requests from a different subnet. A workaround is to NAT your Home Assistant IP to the device's subnet.
 
 ### Add device using host/token:
 Suitable for devices support miot-spec protocol in LAN


### PR DESCRIPTION
Add a note to the readme, that for local control to work, the HASS server needs to be on the same subnet as the device. Newer devices drop control requests from different subnets, even if mDNS is working and the devices can ping at the network layer.

I spend many hours troubleshooting before I stumbled across this requirement for my Xiaomi Smart Humidifier 2.