### PR TITLE
Add Xiaomi Pet Fountain 2 UI improvements and MIoT time entity support

### DIFF
--- a/custom_components/xiaomi_miot/core/const.py
+++ b/custom_components/xiaomi_miot/core/const.py
@@ -27,6 +27,7 @@ SUPPORTED_DOMAINS = [
     'select',
     'button',
     'text',
+    'time',
     'light',
     'fan',
     'climate',

--- a/custom_components/xiaomi_miot/core/converters.py
+++ b/custom_components/xiaomi_miot/core/converters.py
@@ -218,7 +218,7 @@ class MiotBrightnessConv(MiotPropConv):
 class MiotTimePropConv(MiotPropConv):
     def decode(self, device: 'Device', payload: dict, value: int):
         from datetime import time
-        h, remainder = divmod(int(value), 3600)
+        h, remainder = divmod(value, 3600)
         m, s = divmod(remainder, 60)
         super().decode(device, payload, time(h % 24, m, s))
 

--- a/custom_components/xiaomi_miot/core/converters.py
+++ b/custom_components/xiaomi_miot/core/converters.py
@@ -215,6 +215,20 @@ class MiotBrightnessConv(MiotPropConv):
             super().encode(device, payload, int(value))
 
 @dataclass
+class MiotTimePropConv(MiotPropConv):
+    def decode(self, device: 'Device', payload: dict, value: int):
+        from datetime import time
+        h, remainder = divmod(int(value), 3600)
+        m, s = divmod(remainder, 60)
+        super().decode(device, payload, time(h % 24, m, s))
+
+    def encode(self, device: 'Device', payload: dict, value):
+        from datetime import time as dt_time
+        if isinstance(value, dt_time):
+            seconds = value.hour * 3600 + value.minute * 60 + value.second
+            super().encode(device, payload, seconds)
+
+@dataclass
 class MiotColorTempConv(MiotPropConv):
     def decode(self, device: 'Device', payload: dict, value: int):
         if self.prop.unit == 'percentage':

--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -25,7 +25,7 @@ from .hass_entity import XEntity, BasicEntity, convert_unique_id
 from .converters import (
     BaseConv, InfoConv, MiotPropConv,
     MiotPropValueConv, MiotActionConv,
-    AttrConv, MiotTargetPositionConv,
+    AttrConv, MiotTargetPositionConv, MiotTimePropConv,
 )
 from .coordinator import DataCoordinator
 from .miot_spec import MiotSpec, MiotProperty, MiotResults, MiotResult
@@ -445,7 +445,7 @@ class Device(CustomConfigHelper):
 
         for d in [
             'button', 'sensor', 'binary_sensor', 'switch', 'number', 'select', 'text',
-            'number_select', 'scanner', 'target_position',
+            'time', 'number_select', 'scanner', 'target_position',
         ]:
             pls = self.custom_config_list(f'{d}_properties') or []
             if not pls:
@@ -484,6 +484,7 @@ class Device(CustomConfigHelper):
                 else:
                     conv_cls = {
                         'target_position': MiotTargetPositionConv,
+                        'time': MiotTimePropConv,
                     }.get(d) or MiotPropConv
                     conv = conv_cls(prop.full_name, platform, prop=prop)
                     conv.with_option(

--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2344,16 +2344,67 @@ DEVICE_CUSTOMIZES = {
         'button_actions': 'reset_filter_life',
         'switch_properties': 'no_disturb,physical_controls_locked',
         'sensor_properties': 'status,filter_life_level,filter_left_time,battery_level,charging_state',
-        'number_properties': 'out_water_interval,time_period_start,time_period_end',
+        'number_properties': 'out_water_interval',
+        'time_properties': 'time_period_start,time_period_end',
         'select_properties': 'mode',
-        'exclude_miot_properties': 'event_time,event_mode,event_water,event_timezone'
+        'exclude_miot_properties': 'event_time,event_mode,event_water,event_timezone,factory_mode_switch',
+        'chunk_coordinators': [
+            {'interval': 15, 'props': 'status,water_shortage_status,pump_block,fault'},
+            {'interval': 30, 'props': 'battery_level,charging_state,low_battery,usb_insert_state'},
+            {'interval': 60, 'props': 'mode,out_water_interval,no_disturb,physical_controls_locked,time_period_start,time_period_end'},
+            {'interval': 300, 'props': 'filter_life_level,filter_left_time'},
+        ],
     },
     'xiaomi.pet_waterer.70m2:fault': {
-         'reverse_state': True,
+        'reverse_state': True,
+    },
+    'xiaomi.pet_waterer.70m2:status': {
+        'icon': 'mdi:fountain',
+    },
+    'xiaomi.pet_waterer.70m2:water_shortage_status': {
+        'icon': 'mdi:water-alert',
+    },
+    'xiaomi.pet_waterer.70m2:pump_block': {
+        'icon': 'mdi:pump-off',
+    },
+    'xiaomi.pet_waterer.70m2:usb_insert_state': {
+        'icon': 'mdi:usb',
+    },
+    'xiaomi.pet_waterer.70m2:low_battery': {
+        'icon': 'mdi:battery-alert-variant-outline',
+    },
+    'xiaomi.pet_waterer.70m2:battery_level': {
+        'state_class': 'measurement',
+    },
+    'xiaomi.pet_waterer.70m2:charging_state': {
+        'icon': 'mdi:battery-charging',
+    },
+    'xiaomi.pet_waterer.70m2:filter_life_level': {
+        'state_class': 'measurement',
+        'icon': 'mdi:filter-check',
     },
     'xiaomi.pet_waterer.70m2:filter_left_time': {
-         'state_class': 'measurement',
-         'unit_of_measurement': 'days',
+        'state_class': 'measurement',
+        'unit_of_measurement': 'days',
+        'icon': 'mdi:filter-cog',
+    },
+    'xiaomi.pet_waterer.70m2:no_disturb': {
+        'icon': 'mdi:moon-waning-crescent',
+    },
+    'xiaomi.pet_waterer.70m2:physical_controls_locked': {
+        'icon': 'mdi:lock',
+    },
+    'xiaomi.pet_waterer.70m2:out_water_interval': {
+        'icon': 'mdi:timer-outline',
+    },
+    'xiaomi.pet_waterer.70m2:time_period_start': {
+        'icon': 'mdi:clock-start',
+    },
+    'xiaomi.pet_waterer.70m2:time_period_end': {
+        'icon': 'mdi:clock-end',
+    },
+    'xiaomi.pet_waterer.70m2:mode': {
+        'icon': 'mdi:water-pump',
     },
     'xiaomi.pet_waterer.iv02': {
         'button_actions': 'reset_filter_life,low_battery,pump_block',

--- a/custom_components/xiaomi_miot/core/hass_entity.py
+++ b/custom_components/xiaomi_miot/core/hass_entity.py
@@ -133,7 +133,7 @@ class XEntity(BasicEntity):
         self._attr_device_info = self.device.hass_device_info
         self._attr_extra_state_attributes = {}
 
-        self._attr_icon = conv.option.get('icon')
+        self._attr_icon = conv.option.get('icon') or self.custom_config('icon')
         self._attr_device_class = self.custom_config('device_class') or conv.option.get('device_class')
 
         if self._attr_translation_key:

--- a/custom_components/xiaomi_miot/core/hass_entity.py
+++ b/custom_components/xiaomi_miot/core/hass_entity.py
@@ -133,7 +133,7 @@ class XEntity(BasicEntity):
         self._attr_device_info = self.device.hass_device_info
         self._attr_extra_state_attributes = {}
 
-        self._attr_icon = conv.option.get('icon') or self.custom_config('icon')
+        self._attr_icon = self.custom_config('icon') or conv.option.get('icon')
         self._attr_device_class = self.custom_config('device_class') or conv.option.get('device_class')
 
         if self._attr_translation_key:

--- a/custom_components/xiaomi_miot/time.py
+++ b/custom_components/xiaomi_miot/time.py
@@ -1,0 +1,49 @@
+"""Support time entity for Xiaomi Miot."""
+import logging
+
+from homeassistant.components.time import (
+    DOMAIN as ENTITY_DOMAIN,
+    TimeEntity as BaseEntity,
+)
+
+from . import (
+    DOMAIN,
+    XIAOMI_CONFIG_SCHEMA as PLATFORM_SCHEMA,  # noqa: F401
+    HassEntry,
+    XEntity,
+    async_setup_config_entry,
+    bind_services_to_entries,
+)
+
+_LOGGER = logging.getLogger(__name__)
+DATA_KEY = f'{ENTITY_DOMAIN}.{DOMAIN}'
+
+SERVICE_TO_METHOD = {}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    HassEntry.init(hass, config_entry).new_adder(ENTITY_DOMAIN, async_add_entities)
+    await async_setup_config_entry(hass, config_entry, async_setup_platform, async_add_entities, ENTITY_DOMAIN)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    hass.data[DOMAIN]['add_entities'][ENTITY_DOMAIN] = async_add_entities
+    bind_services_to_entries(hass, SERVICE_TO_METHOD)
+
+
+class TimeEntity(XEntity, BaseEntity):
+    _attr_native_value = None
+
+    def get_state(self) -> dict:
+        return {self.attr: self._attr_native_value}
+
+    def set_state(self, data: dict):
+        val = self.conv.value_from_dict(data)
+        if val is not None:
+            self._attr_native_value = val
+
+    async def async_set_value(self, value):
+        await self.device.async_write({self.attr: value})
+
+
+XEntity.CLS[ENTITY_DOMAIN] = TimeEntity

--- a/custom_components/xiaomi_miot/translations/cs.json
+++ b/custom_components/xiaomi_miot/translations/cs.json
@@ -123,6 +123,29 @@
       "show_customizes": "{link}\n{tip}"
     }
   },
+  "entity": {
+    "binary_sensor": {
+      "pet_drinking_fountain-water_shortage_status": {"name": "Nedostatek vody"},
+      "pet_drinking_fountain-fault": {"name": "Porucha"},
+      "pet_waterer_costom-usb_insert_state": {"name": "USB napájení"},
+      "pet_waterer_costom-low_battery": {"name": "Nízká baterie"},
+      "pet_waterer_costom-pump_block": {"name": "Zablokované čerpadlo"}
+    },
+    "switch": {
+      "no_disturb-no_disturb": {"name": "Nerušit"},
+      "physical_controls_locked-physical_controls_locked": {"name": "Dětský zámek"}
+    },
+    "select": {
+      "pet_drinking_fountain-mode": {"name": "Režim vody"}
+    },
+    "number": {
+      "pet_drinking_fountain-out_water_interval": {"name": "Interval vody"}
+    },
+    "time": {
+      "pet_waterer_costom-time_period_start": {"name": "Začátek DND"},
+      "pet_waterer_costom-time_period_end": {"name": "Konec DND"}
+    }
+  },
   "system_health": {
     "info": {
       "component_version": "Verze komponenty",

--- a/custom_components/xiaomi_miot/translations/cs.json
+++ b/custom_components/xiaomi_miot/translations/cs.json
@@ -126,10 +126,7 @@
   "entity": {
     "binary_sensor": {
       "pet_drinking_fountain-water_shortage_status": {"name": "Nedostatek vody"},
-      "pet_drinking_fountain-fault": {"name": "Porucha"},
-      "pet_waterer_costom-usb_insert_state": {"name": "USB napájení"},
-      "pet_waterer_costom-low_battery": {"name": "Nízká baterie"},
-      "pet_waterer_costom-pump_block": {"name": "Zablokované čerpadlo"}
+      "pet_drinking_fountain-fault": {"name": "Porucha"}
     },
     "switch": {
       "no_disturb-no_disturb": {"name": "Nerušit"},
@@ -140,10 +137,6 @@
     },
     "number": {
       "pet_drinking_fountain-out_water_interval": {"name": "Interval vody"}
-    },
-    "time": {
-      "pet_waterer_costom-time_period_start": {"name": "Začátek DND"},
-      "pet_waterer_costom-time_period_end": {"name": "Konec DND"}
     }
   },
   "system_health": {

--- a/custom_components/xiaomi_miot/translations/de.json
+++ b/custom_components/xiaomi_miot/translations/de.json
@@ -126,10 +126,7 @@
     "entity": {
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Wassermangel"},
-            "pet_drinking_fountain-fault": {"name": "Fehler"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB-Strom"},
-            "pet_waterer_costom-low_battery": {"name": "Niedriger Akkustand"},
-            "pet_waterer_costom-pump_block": {"name": "Pumpe blockiert"}
+            "pet_drinking_fountain-fault": {"name": "Fehler"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Nicht stören"},
@@ -140,10 +137,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Wasserintervall"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "DND Start"},
-            "pet_waterer_costom-time_period_end": {"name": "DND Ende"}
         }
     },
     "system_health": {

--- a/custom_components/xiaomi_miot/translations/de.json
+++ b/custom_components/xiaomi_miot/translations/de.json
@@ -123,6 +123,29 @@
             "show_customizes": "[Neue Integration hinzufügen](/_my_redirect/config_flow_start?domain=xiaomi_miot) um Anpassungen zu bearbeiten.\n{link}\n{tip}"
         }
     },
+    "entity": {
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Wassermangel"},
+            "pet_drinking_fountain-fault": {"name": "Fehler"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB-Strom"},
+            "pet_waterer_costom-low_battery": {"name": "Niedriger Akkustand"},
+            "pet_waterer_costom-pump_block": {"name": "Pumpe blockiert"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Nicht stören"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Kindersicherung"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Wassermodus"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Wasserintervall"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "DND Start"},
+            "pet_waterer_costom-time_period_end": {"name": "DND Ende"}
+        }
+    },
     "system_health": {
         "info": {
             "component_version": "Komponenten-Version",

--- a/custom_components/xiaomi_miot/translations/el.json
+++ b/custom_components/xiaomi_miot/translations/el.json
@@ -126,10 +126,7 @@
    "entity":{
       "binary_sensor":{
          "pet_drinking_fountain-water_shortage_status":{"name":"Έλλειψη νερού"},
-         "pet_drinking_fountain-fault":{"name":"Σφάλμα"},
-         "pet_waterer_costom-usb_insert_state":{"name":"Τροφοδοσία USB"},
-         "pet_waterer_costom-low_battery":{"name":"Χαμηλή μπαταρία"},
-         "pet_waterer_costom-pump_block":{"name":"Μπλοκαρισμένη αντλία"}
+         "pet_drinking_fountain-fault":{"name":"Σφάλμα"}
       },
       "switch":{
          "no_disturb-no_disturb":{"name":"Μην ενοχλείτε"},
@@ -140,10 +137,6 @@
       },
       "number":{
          "pet_drinking_fountain-out_water_interval":{"name":"Διάστημα νερού"}
-      },
-      "time":{
-         "pet_waterer_costom-time_period_start":{"name":"Έναρξη DND"},
-         "pet_waterer_costom-time_period_end":{"name":"Λήξη DND"}
       }
    },
    "system_health":{

--- a/custom_components/xiaomi_miot/translations/el.json
+++ b/custom_components/xiaomi_miot/translations/el.json
@@ -123,6 +123,29 @@
          "show_customizes":"[Προσθήκη νέας ενσωμάτωσης] (/_my_redirect/config_flow_start?domain=xiaomi_miot) για να τροποποιήσετε την προσαρμογή.\n{link}\n{tip}"
       }
    },
+   "entity":{
+      "binary_sensor":{
+         "pet_drinking_fountain-water_shortage_status":{"name":"Έλλειψη νερού"},
+         "pet_drinking_fountain-fault":{"name":"Σφάλμα"},
+         "pet_waterer_costom-usb_insert_state":{"name":"Τροφοδοσία USB"},
+         "pet_waterer_costom-low_battery":{"name":"Χαμηλή μπαταρία"},
+         "pet_waterer_costom-pump_block":{"name":"Μπλοκαρισμένη αντλία"}
+      },
+      "switch":{
+         "no_disturb-no_disturb":{"name":"Μην ενοχλείτε"},
+         "physical_controls_locked-physical_controls_locked":{"name":"Παιδικό κλείδωμα"}
+      },
+      "select":{
+         "pet_drinking_fountain-mode":{"name":"Λειτουργία νερού"}
+      },
+      "number":{
+         "pet_drinking_fountain-out_water_interval":{"name":"Διάστημα νερού"}
+      },
+      "time":{
+         "pet_waterer_costom-time_period_start":{"name":"Έναρξη DND"},
+         "pet_waterer_costom-time_period_end":{"name":"Λήξη DND"}
+      }
+   },
    "system_health":{
       "info":{
          "component_version":"Έκδοση στοιχείου",

--- a/custom_components/xiaomi_miot/translations/en.json
+++ b/custom_components/xiaomi_miot/translations/en.json
@@ -118,6 +118,7 @@
                     "target_position_properties": "target_position_properties",
                     "television_name": "television_name",
                     "text_actions": "text_actions",
+                    "time_properties": "time_properties",
                     "turn_on_hvac": "turn_on_hvac",
                     "unit_of_measurement": "unit_of_measurement",
                     "value_ratio": "value_ratio",
@@ -265,6 +266,27 @@
                     "stuck": "Stuck"
                 }
             }
+        },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Water Shortage"},
+            "pet_drinking_fountain-fault": {"name": "Fault"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB Power"},
+            "pet_waterer_costom-low_battery": {"name": "Low Battery"},
+            "pet_waterer_costom-pump_block": {"name": "Pump Blocked"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Do Not Disturb"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Child Lock"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Water Mode"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Water Interval"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "DND Start"},
+            "pet_waterer_costom-time_period_end": {"name": "DND End"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/en.json
+++ b/custom_components/xiaomi_miot/translations/en.json
@@ -269,10 +269,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Water Shortage"},
-            "pet_drinking_fountain-fault": {"name": "Fault"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB Power"},
-            "pet_waterer_costom-low_battery": {"name": "Low Battery"},
-            "pet_waterer_costom-pump_block": {"name": "Pump Blocked"}
+            "pet_drinking_fountain-fault": {"name": "Fault"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Do Not Disturb"},
@@ -283,10 +280,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Water Interval"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "DND Start"},
-            "pet_waterer_costom-time_period_end": {"name": "DND End"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/es.json
+++ b/custom_components/xiaomi_miot/translations/es.json
@@ -174,6 +174,27 @@
         }
       }
     },
+    "binary_sensor": {
+      "pet_drinking_fountain-water_shortage_status": {"name": "Falta de agua"},
+      "pet_drinking_fountain-fault": {"name": "Fallo"},
+      "pet_waterer_costom-usb_insert_state": {"name": "Alimentación USB"},
+      "pet_waterer_costom-low_battery": {"name": "Batería baja"},
+      "pet_waterer_costom-pump_block": {"name": "Bomba bloqueada"}
+    },
+    "switch": {
+      "no_disturb-no_disturb": {"name": "No molestar"},
+      "physical_controls_locked-physical_controls_locked": {"name": "Bloqueo infantil"}
+    },
+    "select": {
+      "pet_drinking_fountain-mode": {"name": "Modo de agua"}
+    },
+    "number": {
+      "pet_drinking_fountain-out_water_interval": {"name": "Intervalo de agua"}
+    },
+    "time": {
+      "pet_waterer_costom-time_period_start": {"name": "Inicio DND"},
+      "pet_waterer_costom-time_period_end": {"name": "Fin DND"}
+    },
     "climate": {
       "air_conditioner": {
         "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/es.json
+++ b/custom_components/xiaomi_miot/translations/es.json
@@ -176,10 +176,7 @@
     },
     "binary_sensor": {
       "pet_drinking_fountain-water_shortage_status": {"name": "Falta de agua"},
-      "pet_drinking_fountain-fault": {"name": "Fallo"},
-      "pet_waterer_costom-usb_insert_state": {"name": "Alimentación USB"},
-      "pet_waterer_costom-low_battery": {"name": "Batería baja"},
-      "pet_waterer_costom-pump_block": {"name": "Bomba bloqueada"}
+      "pet_drinking_fountain-fault": {"name": "Fallo"}
     },
     "switch": {
       "no_disturb-no_disturb": {"name": "No molestar"},
@@ -190,10 +187,6 @@
     },
     "number": {
       "pet_drinking_fountain-out_water_interval": {"name": "Intervalo de agua"}
-    },
-    "time": {
-      "pet_waterer_costom-time_period_start": {"name": "Inicio DND"},
-      "pet_waterer_costom-time_period_end": {"name": "Fin DND"}
     },
     "climate": {
       "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/fr.json
+++ b/custom_components/xiaomi_miot/translations/fr.json
@@ -123,6 +123,29 @@
             "show_customizes": "[Ajouter une nouvelle intégration](/_my_redirect/config_flow_start?domain=xiaomi_miot) pour modifier la personnalisation.\n{link}\n{tip}"
         }
     },
+    "entity": {
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Manque d'eau"},
+            "pet_drinking_fountain-fault": {"name": "Défaut"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Alimentation USB"},
+            "pet_waterer_costom-low_battery": {"name": "Batterie faible"},
+            "pet_waterer_costom-pump_block": {"name": "Pompe bloquée"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Ne pas déranger"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Verrou enfant"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Mode d'eau"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Intervalle d'eau"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Début DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Fin DND"}
+        }
+    },
     "system_health": {
         "info": {
             "component_version": "Version de composant",

--- a/custom_components/xiaomi_miot/translations/fr.json
+++ b/custom_components/xiaomi_miot/translations/fr.json
@@ -126,10 +126,7 @@
     "entity": {
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Manque d'eau"},
-            "pet_drinking_fountain-fault": {"name": "Défaut"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Alimentation USB"},
-            "pet_waterer_costom-low_battery": {"name": "Batterie faible"},
-            "pet_waterer_costom-pump_block": {"name": "Pompe bloquée"}
+            "pet_drinking_fountain-fault": {"name": "Défaut"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Ne pas déranger"},
@@ -140,10 +137,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Intervalle d'eau"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Début DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Fin DND"}
         }
     },
     "system_health": {

--- a/custom_components/xiaomi_miot/translations/hu.json
+++ b/custom_components/xiaomi_miot/translations/hu.json
@@ -209,10 +209,7 @@
         ,
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Kevés víz"},
-            "pet_drinking_fountain-fault": {"name": "Hiba"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB tápellátás"},
-            "pet_waterer_costom-low_battery": {"name": "Alacsony töltöttség"},
-            "pet_waterer_costom-pump_block": {"name": "Szivattyú elakadva"}
+            "pet_drinking_fountain-fault": {"name": "Hiba"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Ne zavarjanak"},
@@ -223,10 +220,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Víz intervallum"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "DND kezdete"},
-            "pet_waterer_costom-time_period_end": {"name": "DND vége"}
         }
     },
     "services": {

--- a/custom_components/xiaomi_miot/translations/hu.json
+++ b/custom_components/xiaomi_miot/translations/hu.json
@@ -206,6 +206,28 @@
                 }
             }
         }
+        ,
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Kevés víz"},
+            "pet_drinking_fountain-fault": {"name": "Hiba"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB tápellátás"},
+            "pet_waterer_costom-low_battery": {"name": "Alacsony töltöttség"},
+            "pet_waterer_costom-pump_block": {"name": "Szivattyú elakadva"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Ne zavarjanak"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Gyerekzár"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Víz mód"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Víz intervallum"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "DND kezdete"},
+            "pet_waterer_costom-time_period_end": {"name": "DND vége"}
+        }
     },
     "services": {
         "send_command": {

--- a/custom_components/xiaomi_miot/translations/it.json
+++ b/custom_components/xiaomi_miot/translations/it.json
@@ -177,10 +177,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Acqua insufficiente"},
-            "pet_drinking_fountain-fault": {"name": "Guasto"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Alimentazione USB"},
-            "pet_waterer_costom-low_battery": {"name": "Batteria scarica"},
-            "pet_waterer_costom-pump_block": {"name": "Pompa bloccata"}
+            "pet_drinking_fountain-fault": {"name": "Guasto"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Non disturbare"},
@@ -191,10 +188,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Intervallo acqua"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Inizio DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Fine DND"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/it.json
+++ b/custom_components/xiaomi_miot/translations/it.json
@@ -175,6 +175,27 @@
                 }
             }
         },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Acqua insufficiente"},
+            "pet_drinking_fountain-fault": {"name": "Guasto"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Alimentazione USB"},
+            "pet_waterer_costom-low_battery": {"name": "Batteria scarica"},
+            "pet_waterer_costom-pump_block": {"name": "Pompa bloccata"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Non disturbare"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Blocco bambini"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Modalità acqua"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Intervallo acqua"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Inizio DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Fine DND"}
+        },
         "climate": {
             "air_conditioner": {
                 "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/pl.json
+++ b/custom_components/xiaomi_miot/translations/pl.json
@@ -126,10 +126,7 @@
     "entity": {
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Brak wody"},
-            "pet_drinking_fountain-fault": {"name": "Usterka"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Zasilanie USB"},
-            "pet_waterer_costom-low_battery": {"name": "Niski poziom baterii"},
-            "pet_waterer_costom-pump_block": {"name": "Zablokowana pompa"}
+            "pet_drinking_fountain-fault": {"name": "Usterka"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Nie przeszkadzać"},
@@ -140,10 +137,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Interwał wody"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Początek DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Koniec DND"}
         }
     },
     "system_health": {

--- a/custom_components/xiaomi_miot/translations/pl.json
+++ b/custom_components/xiaomi_miot/translations/pl.json
@@ -123,6 +123,29 @@
             "show_customizes": "[Add a new integration](/_my_redirect/config_flow_start?domain=xiaomi_miot) to modify customization.\n{link}\n{tip}"
         }
     },
+    "entity": {
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Brak wody"},
+            "pet_drinking_fountain-fault": {"name": "Usterka"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Zasilanie USB"},
+            "pet_waterer_costom-low_battery": {"name": "Niski poziom baterii"},
+            "pet_waterer_costom-pump_block": {"name": "Zablokowana pompa"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Nie przeszkadzać"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Blokada rodzicielska"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Tryb wody"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Interwał wody"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Początek DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Koniec DND"}
+        }
+    },
     "system_health": {
         "info": {
             "component_version": "Wersja komponentu",

--- a/custom_components/xiaomi_miot/translations/pt-BR.json
+++ b/custom_components/xiaomi_miot/translations/pt-BR.json
@@ -175,6 +175,27 @@
                 }
             }
         },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Falta de água"},
+            "pet_drinking_fountain-fault": {"name": "Falha"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Energia USB"},
+            "pet_waterer_costom-low_battery": {"name": "Bateria fraca"},
+            "pet_waterer_costom-pump_block": {"name": "Bomba bloqueada"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Não perturbe"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Trava infantil"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Modo de água"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Intervalo de água"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Início DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Fim DND"}
+        },
         "climate": {
             "air_conditioner": {
                 "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/pt-BR.json
+++ b/custom_components/xiaomi_miot/translations/pt-BR.json
@@ -177,10 +177,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Falta de água"},
-            "pet_drinking_fountain-fault": {"name": "Falha"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Energia USB"},
-            "pet_waterer_costom-low_battery": {"name": "Bateria fraca"},
-            "pet_waterer_costom-pump_block": {"name": "Bomba bloqueada"}
+            "pet_drinking_fountain-fault": {"name": "Falha"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Não perturbe"},
@@ -191,10 +188,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Intervalo de água"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Início DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Fim DND"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/ru.json
+++ b/custom_components/xiaomi_miot/translations/ru.json
@@ -120,6 +120,29 @@
             "show_customizes": "[Add a new integration](/_my_redirect/config_flow_start?domain=xiaomi_miot) to modify customization.\n{link}\n{tip}"
         }
     },
+    "entity": {
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Недостаток воды"},
+            "pet_drinking_fountain-fault": {"name": "Неисправность"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Питание USB"},
+            "pet_waterer_costom-low_battery": {"name": "Низкий заряд"},
+            "pet_waterer_costom-pump_block": {"name": "Блокировка помпы"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Не беспокоить"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Детский замок"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Режим воды"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Интервал воды"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Начало DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Конец DND"}
+        }
+    },
     "system_health": {
         "info": {
             "component_version": "Версия компонента",

--- a/custom_components/xiaomi_miot/translations/ru.json
+++ b/custom_components/xiaomi_miot/translations/ru.json
@@ -123,10 +123,7 @@
     "entity": {
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Недостаток воды"},
-            "pet_drinking_fountain-fault": {"name": "Неисправность"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Питание USB"},
-            "pet_waterer_costom-low_battery": {"name": "Низкий заряд"},
-            "pet_waterer_costom-pump_block": {"name": "Блокировка помпы"}
+            "pet_drinking_fountain-fault": {"name": "Неисправность"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Не беспокоить"},
@@ -137,10 +134,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Интервал воды"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Начало DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Конец DND"}
         }
     },
     "system_health": {

--- a/custom_components/xiaomi_miot/translations/tr.json
+++ b/custom_components/xiaomi_miot/translations/tr.json
@@ -206,10 +206,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Su Az"},
-            "pet_drinking_fountain-fault": {"name": "Arıza"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB Gücü"},
-            "pet_waterer_costom-low_battery": {"name": "Düşük Pil"},
-            "pet_waterer_costom-pump_block": {"name": "Pompa Tıkalı"}
+            "pet_drinking_fountain-fault": {"name": "Arıza"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Rahatsız Etme"},
@@ -220,10 +217,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Su Aralığı"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "DND Başlangıç"},
-            "pet_waterer_costom-time_period_end": {"name": "DND Bitiş"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/tr.json
+++ b/custom_components/xiaomi_miot/translations/tr.json
@@ -204,6 +204,27 @@
                 }
             }
         },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Su Az"},
+            "pet_drinking_fountain-fault": {"name": "Arıza"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB Gücü"},
+            "pet_waterer_costom-low_battery": {"name": "Düşük Pil"},
+            "pet_waterer_costom-pump_block": {"name": "Pompa Tıkalı"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Rahatsız Etme"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Çocuk Kilidi"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Su Modu"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Su Aralığı"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "DND Başlangıç"},
+            "pet_waterer_costom-time_period_end": {"name": "DND Bitiş"}
+        },
         "climate": {
             "air_conditioner": {
                 "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/uk.json
+++ b/custom_components/xiaomi_miot/translations/uk.json
@@ -224,10 +224,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Нестача води"},
-            "pet_drinking_fountain-fault": {"name": "Несправність"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Живлення USB"},
-            "pet_waterer_costom-low_battery": {"name": "Низький заряд"},
-            "pet_waterer_costom-pump_block": {"name": "Блокування помпи"}
+            "pet_drinking_fountain-fault": {"name": "Несправність"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Не турбувати"},
@@ -238,10 +235,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Інтервал води"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Початок DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Кінець DND"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/uk.json
+++ b/custom_components/xiaomi_miot/translations/uk.json
@@ -222,6 +222,27 @@
                 }
             }
         },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Нестача води"},
+            "pet_drinking_fountain-fault": {"name": "Несправність"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Живлення USB"},
+            "pet_waterer_costom-low_battery": {"name": "Низький заряд"},
+            "pet_waterer_costom-pump_block": {"name": "Блокування помпи"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Не турбувати"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Дитячий замок"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Режим води"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Інтервал води"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Початок DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Кінець DND"}
+        },
         "climate": {
             "air_conditioner": {
                 "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/vi.json
+++ b/custom_components/xiaomi_miot/translations/vi.json
@@ -206,10 +206,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "Thiếu nước"},
-            "pet_drinking_fountain-fault": {"name": "Lỗi"},
-            "pet_waterer_costom-usb_insert_state": {"name": "Nguồn USB"},
-            "pet_waterer_costom-low_battery": {"name": "Pin yếu"},
-            "pet_waterer_costom-pump_block": {"name": "Bơm bị kẹt"}
+            "pet_drinking_fountain-fault": {"name": "Lỗi"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "Không làm phiền"},
@@ -220,10 +217,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "Chu kỳ nước"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "Bắt đầu DND"},
-            "pet_waterer_costom-time_period_end": {"name": "Kết thúc DND"}
         },
         "climate": {
             "air_conditioner": {

--- a/custom_components/xiaomi_miot/translations/vi.json
+++ b/custom_components/xiaomi_miot/translations/vi.json
@@ -204,6 +204,27 @@
                 }
             }
         },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "Thiếu nước"},
+            "pet_drinking_fountain-fault": {"name": "Lỗi"},
+            "pet_waterer_costom-usb_insert_state": {"name": "Nguồn USB"},
+            "pet_waterer_costom-low_battery": {"name": "Pin yếu"},
+            "pet_waterer_costom-pump_block": {"name": "Bơm bị kẹt"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "Không làm phiền"},
+            "physical_controls_locked-physical_controls_locked": {"name": "Khóa trẻ em"}
+        },
+        "select": {
+            "pet_drinking_fountain-mode": {"name": "Chế độ nước"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "Chu kỳ nước"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "Bắt đầu DND"},
+            "pet_waterer_costom-time_period_end": {"name": "Kết thúc DND"}
+        },
         "climate": {
             "air_conditioner": {
                 "state_attributes": {

--- a/custom_components/xiaomi_miot/translations/zh-Hans.json
+++ b/custom_components/xiaomi_miot/translations/zh-Hans.json
@@ -315,10 +315,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "缺水"},
-            "pet_drinking_fountain-fault": {"name": "故障"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB供电"},
-            "pet_waterer_costom-low_battery": {"name": "低电量"},
-            "pet_waterer_costom-pump_block": {"name": "水泵堵塞"}
+            "pet_drinking_fountain-fault": {"name": "故障"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "勿扰模式"},
@@ -326,10 +323,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "出水间隔"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "勿扰开始"},
-            "pet_waterer_costom-time_period_end": {"name": "勿扰结束"}
         },
         "humidifier": {
             "humidifier": {

--- a/custom_components/xiaomi_miot/translations/zh-Hans.json
+++ b/custom_components/xiaomi_miot/translations/zh-Hans.json
@@ -283,6 +283,7 @@
             }
         },
         "select": {
+            "pet_drinking_fountain-mode": {"name": "出水模式"},
             "fan_control-fan_level": {
                 "state": {
                     "auto": "自动",
@@ -311,6 +312,24 @@
                 "Scene": "场景",
                 "Music": "音乐"
             }
+        },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "缺水"},
+            "pet_drinking_fountain-fault": {"name": "故障"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB供电"},
+            "pet_waterer_costom-low_battery": {"name": "低电量"},
+            "pet_waterer_costom-pump_block": {"name": "水泵堵塞"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "勿扰模式"},
+            "physical_controls_locked-physical_controls_locked": {"name": "童锁"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "出水间隔"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "勿扰开始"},
+            "pet_waterer_costom-time_period_end": {"name": "勿扰结束"}
         },
         "humidifier": {
             "humidifier": {

--- a/custom_components/xiaomi_miot/translations/zh-Hant.json
+++ b/custom_components/xiaomi_miot/translations/zh-Hant.json
@@ -303,10 +303,7 @@
         },
         "binary_sensor": {
             "pet_drinking_fountain-water_shortage_status": {"name": "缺水"},
-            "pet_drinking_fountain-fault": {"name": "故障"},
-            "pet_waterer_costom-usb_insert_state": {"name": "USB供電"},
-            "pet_waterer_costom-low_battery": {"name": "低電量"},
-            "pet_waterer_costom-pump_block": {"name": "水泵堵塞"}
+            "pet_drinking_fountain-fault": {"name": "故障"}
         },
         "switch": {
             "no_disturb-no_disturb": {"name": "勿擾模式"},
@@ -314,10 +311,6 @@
         },
         "number": {
             "pet_drinking_fountain-out_water_interval": {"name": "出水間隔"}
-        },
-        "time": {
-            "pet_waterer_costom-time_period_start": {"name": "勿擾開始"},
-            "pet_waterer_costom-time_period_end": {"name": "勿擾結束"}
         }
     },
     "services": {

--- a/custom_components/xiaomi_miot/translations/zh-Hant.json
+++ b/custom_components/xiaomi_miot/translations/zh-Hant.json
@@ -271,6 +271,7 @@
             }
         },
         "select": {
+            "pet_drinking_fountain-mode": {"name": "出水模式"},
             "fan_control-fan_level": {
                 "state": {
                     "auto": "自動",
@@ -299,6 +300,24 @@
                 "Scene": "場景",
                 "Music": "音樂"
             }
+        },
+        "binary_sensor": {
+            "pet_drinking_fountain-water_shortage_status": {"name": "缺水"},
+            "pet_drinking_fountain-fault": {"name": "故障"},
+            "pet_waterer_costom-usb_insert_state": {"name": "USB供電"},
+            "pet_waterer_costom-low_battery": {"name": "低電量"},
+            "pet_waterer_costom-pump_block": {"name": "水泵堵塞"}
+        },
+        "switch": {
+            "no_disturb-no_disturb": {"name": "勿擾模式"},
+            "physical_controls_locked-physical_controls_locked": {"name": "童鎖"}
+        },
+        "number": {
+            "pet_drinking_fountain-out_water_interval": {"name": "出水間隔"}
+        },
+        "time": {
+            "pet_waterer_costom-time_period_start": {"name": "勿擾開始"},
+            "pet_waterer_costom-time_period_end": {"name": "勿擾結束"}
         }
     },
     "services": {


### PR DESCRIPTION
## Summary

This PR improves support for the Xiaomi Pet Fountain 2 (`xiaomi.pet_waterer.70m2`) in `xiaomi_miot` and adds MIoT `time` entity support for time-based properties.

## What changed

### Pet Fountain improvements
- add icons for pet fountain entities
- add chunked polling for faster updates on critical states
- expose battery and filter values with measurement state class
- remove `factory_mode_switch` from exposed entities
- move DND start/end from `number` properties to `time` properties

### Generic integration improvements
- allow entity `icon` overrides from `DEVICE_CUSTOMIZES`
- add `time` to supported platforms
- add `MiotTimePropConv` for MIoT properties represented as seconds since midnight
- add a new `time` platform implementation

### Translations
- add pet fountain entity names in English and other shipped locales

## Tested

Tested on a Home Assistant instance with a real `xiaomi.pet_waterer.70m2` device.

Verified:
- icons appear correctly
- DND start/end are shown as time pickers instead of raw seconds
- entity polling behaves as expected
- battery/filter stats are exposed correctly
- unwanted debug property is no longer shown
