### PR TITLE
Add xiaomi.fan.p70 device customization

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2246,6 +2246,13 @@ DEVICE_CUSTOMIZES = {
         'select_properties': 'horizontal_swing_included_angle',
         'number_properties': 'delay_time',
     },
+    'xiaomi.fan.p70': {
+        'button_actions': 'toggle,toggle_mode,loop_gear,turn_left,turn_right,turn_upward,turn_downward',
+        'switch_properties': 'indicator_light.on,alarm,physical_controls_locked,horizontal_swing,vertical_swing,delay',
+        'number_select_properties': 'horizontal_swing_included_angle,vertical_swing_included_angle',
+        'number_properties': 'delay_time',
+        'sensor_properties': 'delay_remain_time',
+    },
     'xiaomi.feeder.iv2001': {
         'button_actions': 'pet_food_out,reset_desiccant_life,weigh_manual_calibrate',
         'binary_sensor_properties': 'battery_level',


### PR DESCRIPTION
Adds model-specific customization for `xiaomi.fan.p70` based on the raw MIoT spec.

Confirmed on raw spec:
- button actions:
  - `toggle`
  - `toggle_mode`
  - `loop_gear`
  - `turn_left`
  - `turn_right`
  - `turn_upward`
  - `turn_downward`
- switch properties:
  - `indicator_light.on`
  - `alarm`
  - `physical_controls_locked`
  - `horizontal_swing`
  - `vertical_swing`
  - `delay`
- number/select properties:
  - `horizontal_swing_included_angle`
  - `vertical_swing_included_angle`
- number property:
  - `delay_time`
- sensor property:
  - `delay_remain_time`

Tested locally in Home Assistant:
- `switch.xiaomi_p70_07ec_horizontal_swing`
- `switch.xiaomi_p70_07ec_vertical_swing`
- `select.xiaomi_p70_07ec_horizontal_swing_included_angle`
- `select.xiaomi_p70_07ec_vertical_swing_included_angle`
- `number.xiaomi_p70_07ec_delay_time`
- `sensor.xiaomi_p70_07ec_delay_remain_time`
- `button.xiaomi_p70_07ec_turn_upward`
- `button.xiaomi_p70_07ec_turn_downward`
- `button.xiaomi_p70_07ec_toggle`
- `button.xiaomi_p70_07ec_toggle_mode`
- `button.xiaomi_p70_07ec_loop_gear`

Raw MIoT spec:
https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:xiaomi-p70:1:0000D062