### PR TITLE
Avoid params list modification when calling action

### DIFF
--- a/custom_components/xiaomi_miot/core/miot_spec.py
+++ b/custom_components/xiaomi_miot/core/miot_spec.py
@@ -1131,11 +1131,7 @@ class MiotAction(MiotSpecInstance):
 
     def in_params(self, params: list):
         pms = []
-        for pid in self.ins:
-            try:
-                val = params.pop(0)
-            except IndexError:
-                break
+        for pid, val in zip(self.ins, params):
             if not (isinstance(val, dict) and 'piid' in val):
                 val = {
                     'piid': pid,


### PR DESCRIPTION
Consider the following way of action calling:

```
- action: xiaomi_miot.call_action
  target: {"entity_id": "vacuum.xiaomi_ov31cn_9c41_robot_cleaner"}
  data:
    siid: 2
    aiid: 16
    params: '{{ [ room_id | string ] }}'
```

2-16 is a "Start Vacuum Room Sweep" action, it expects room id exactly as a string.
We can't pass a string directly because ha casts to number anything that looks like number, even when using the string filter.
HA caches lists created at the template level for some reason, so when we change them, we end up with a modified list on the next invocation.
This fix avoids changing passed parameters, which solves the described problem and is also good practice.
