### PR TITLE
Guard chunked miio response handling

### DIFF
--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -1409,10 +1409,14 @@ class MiotDevice():
             resp = await self.miio.send(method, params[i : i + chunk])
             if not results:
                 self.handle_response(resp)
-            try:
-                results += resp['result']
-            except (KeyError, TypeError):
-                self.log.warning('Got miio chunked properties failed: %s', resp, exc_info=True)
+            if not isinstance(resp, dict) or 'result' not in resp:
+                self.log.warning('Got miio chunked properties failed: %s', resp)
+                return results
+            chunk_results = resp['result']
+            if not isinstance(chunk_results, list):
+                self.log.warning('Got invalid miio chunked properties result: %s', resp)
+                return results
+            results += chunk_results
         return results
 
     def handle_response(self, resp, with_empty=True):


### PR DESCRIPTION
## Summary

This is a narrower replacement for the chunked-response part of https://github.com/al-one/hass-xiaomi-miot/pull/2709.

- keep the current upstream logger formatting unchanged
- handle chunked miio responses that do not contain `result`
- log the failed response without traceback-style noise and return the results collected so far

## Context

The previous PR also changed logging call formatting, and upstream requested an explanation for that part. Upstream later adjusted logging formatting separately, so this PR only keeps the response-shape guard.

## Testing

```sh
python3 -m py_compile custom_components/xiaomi_miot/core/device.py
```
