### PR TITLE
fix: avoid error logs for offline local devices

### DIFF
--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -892,6 +892,8 @@ class Device(CustomConfigHelper):
                 self._local_fails += 1
                 local_state = self._local_fails < 3
                 log = self.log.error
+                if is_offline_exception(exc):
+                    log = self.log.warning
                 if auto_cloud:
                     use_cloud = self.cloud
                     log = self.log.warning


### PR DESCRIPTION
## Summary
- log recognized offline local-device failures as warnings instead of errors
- keep the existing repeated-failure downgrade to info after the device is already known offline

## Validation
- python3 -m py_compile custom_components/xiaomi_miot/core/device.py
- git diff --check
- live Home Assistant smoke on an offline Xiaomi fountain: the repeated local discovery failure is now a warning instead of an error