### PR TITLE
Adds support for `xiaomi.fan.p85` (Mijia Smart Standing Fan Pro Slim)

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2259,6 +2259,21 @@ DEVICE_CUSTOMIZES = {
         'number_properties': 'delay_time',
         'sensor_properties': 'delay_remain_time',
     },
+    'xiaomi.fan.p85': {
+        'sensor_properties': 'fault,delay_remain_time',
+        'button_actions': 'loop_mode,loop_gear,toggle,turn_left,turn_right',
+        'number_select_properties': 'horizontal_swing_included_angle',
+        'select_properties': 'fan.fan_level',
+        'switch_properties': 'delay',
+        'number_properties': 'delay_time',
+        'append_converters': [
+            {
+                'class': MiotFanConv,
+                'services': ['fan'],
+                'converters': [{'props': ['dm_service.fan_level']}],
+            }
+        ],
+    },
     'xiaomi.feeder.iv2001': {
         'button_actions': 'pet_food_out,reset_desiccant_life,weigh_manual_calibrate',
         'binary_sensor_properties': 'battery_level',

--- a/custom_components/xiaomi_miot/core/miot_local_devices.py
+++ b/custom_components/xiaomi_miot/core/miot_local_devices.py
@@ -876,6 +876,7 @@ MIOT_LOCAL_MODELS = [
     'xiaomi.fan.p45',
     'xiaomi.fan.p51',
     'xiaomi.fan.p69',
+    'xiaomi.fan.p85',
     'xiaomi.feeder.iv2001',
     'xiaomi.feeder.pi2001',
     'xiaomi.fishbowl.m200',


### PR DESCRIPTION
MIoT spec link: https://home.miot-spec.com/spec/xiaomi.fan.p85

This fan is the global (EU) version of the Mijia Smart Standing Fan Pro (`xiaomi.fan.p43`). Same fan blades and everything except for the MCU. The Global version uses BL602 while the China one uses ESP8266.

The main difference in the MIoT spec is that the PIID for fan speed percentage is located down under dm-service (SIID 11, PIID 6). This requires the use of a MiotFanConv converter.

Closes issue #2844. Tested and proved to be working on my personal Home Assistant instance (HA 2026.5.0 Container).