### PR TITLE
fix: improve vacuum entity activity mapping and reliability

### DIFF
--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -132,9 +132,12 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
                 self._attr_activity = VacuumActivity.CLEANING
             elif val in self._prop_status.list_search('Idle', 'Sleep'):
                 self._attr_activity = VacuumActivity.IDLE
-            elif val in self._prop_status.list_search('Charging', 'Charging Completed', 'Fullcharge', 'Charge Done', 'Charged', 'Drying'):
+            elif val in self._prop_status.list_search(
+                'Charging', 'Charging Completed', 'Fullcharge', 'Charge Done', 'Charged', 'Drying',
+                'MultiTaskStationWorking', 'StationWorking', 'MultiTaskRecharge', 'WashBreak',
+            ):
                 self._attr_activity = VacuumActivity.DOCKED
-            elif val in self._prop_status.list_search('Go Charging'):
+            elif val in self._prop_status.list_search('Go Charging', 'GoWash', 'Go Wash'):
                 self._attr_activity = VacuumActivity.RETURNING
             elif val in self._prop_status.list_search('Paused'):
                 self._attr_activity = VacuumActivity.PAUSED

--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -113,6 +113,7 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
             self._supported_features |= VacuumEntityFeature.STATE
         if self._act_locate:
             self._supported_features |= VacuumEntityFeature.LOCATE
+        self._supported_features |= VacuumEntityFeature.SEND_COMMAND
 
     async def async_update(self):
         await super().async_update()

--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -132,7 +132,7 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
                 self._attr_activity = VacuumActivity.CLEANING
             elif val in self._prop_status.list_search('Idle', 'Sleep'):
                 self._attr_activity = VacuumActivity.IDLE
-            elif val in self._prop_status.list_search('Charging', 'Charging Completed', 'Fullcharge', 'Charge Done', 'Drying'):
+            elif val in self._prop_status.list_search('Charging', 'Charging Completed', 'Fullcharge', 'Charge Done', 'Charged', 'Drying'):
                 self._attr_activity = VacuumActivity.DOCKED
             elif val in self._prop_status.list_search('Go Charging'):
                 self._attr_activity = VacuumActivity.RETURNING


### PR DESCRIPTION
## Summary

This PR fixes several issues with MiOT vacuum entities:

- **Fix empty response crash** (`async_send_chunk`): avoid log spam/exception when device returns an empty list instead of a dict
- **Enable SEND_COMMAND for all MiOT vacuums**: `VacuumEntityFeature.SEND_COMMAND` was missing from the base `MiotVacuumEntity`, causing HA to reject `vacuum.send_command` calls with "vacuum doesn't support the command"
- **Map `Charged` → DOCKED**: status `Charged` (distinct from `Charging`) was not in the DOCKED list, causing the vacuum to report `idle` when fully charged at base
- **Map station-working states → DOCKED / RETURNING**: base-station states were not mapped, causing incorrect activity reporting during mop washing, auto-empty, and drying cycles:
  - `MultiTaskStationWorking`, `StationWorking`, `MultiTaskRecharge`, `WashBreak` → `DOCKED`
  - `GoWash` → `RETURNING`

Tested on **Xiaomi Robot Vacuum 5 Pro (xiaomi.vacuum.ov21gl)**.

## Test plan
- [ ] Vacuum reports `docked` when fully charged at base (not `idle`)
- [ ] Vacuum reports `docked` while base station is washing mops / auto-emptying / drying
- [ ] Vacuum reports `returning` when travelling to wash station (`GoWash`)
- [ ] `vacuum.send_command` works without "doesn't support the command" error on MiOT-only models

🤖 Generated with [Claude Code](https://claude.com/claude-code)