### PR TITLE
Fix lumi.gateway.mitw01 gateway mappings

### DIFF
--- a/custom_components/xiaomi_miot/core/miio2miot.py
+++ b/custom_components/xiaomi_miot/core/miio2miot.py
@@ -179,6 +179,7 @@ class Miio2MiotHelper:
             if prop := cfg.get('prop'):
                 setter = f'set_{prop}'
         pms = [value]
+        raw_params = False
         prop = self.miot_spec.specs.get(key)
         if prop and isinstance(prop, MiotProperty):
             mph = MiioPropertyHelper(prop, reverse=True)
@@ -196,6 +197,7 @@ class Miio2MiotHelper:
                 }) or []
                 if isinstance(pms, dict) and 'method' in pms:
                     setter = pms.get('method', setter)
+                    raw_params = bool(pms.get('raw_params'))
                     pms = pms.get('params', [])
             elif fmt and hasattr(mph, fmt):
                 pms = [getattr(mph, fmt)(value)]
@@ -204,7 +206,8 @@ class Miio2MiotHelper:
                     if dv == value:
                         pms = [dk]
                         break
-        pms = cv.ensure_list(pms)
+        if not raw_params:
+            pms = cv.ensure_list(pms)
         if not setter:
             _LOGGER.warning('%s: Set miio prop via miot failed: %s', self.model, [key, setter, cfg])
             return None

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -8,7 +8,7 @@ def set_callback_via_param_index(index=0, key=None):
         if prop in props:
             if isinstance(params, dict):
                 props[prop] = params.get(key or prop)
-            elif len(params) > index:
+            elif isinstance(params, (list, tuple)) and len(params) > index:
                 value = params[index]
                 if key and isinstance(value, dict):
                     value = value.get(key)

--- a/custom_components/xiaomi_miot/core/miio2miot_specs.py
+++ b/custom_components/xiaomi_miot/core/miio2miot_specs.py
@@ -3,10 +3,16 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 
-def set_callback_via_param_index(index=0):
+def set_callback_via_param_index(index=0, key=None):
     def cbk(prop, params, props, **kwargs):
-        if prop in props and len(params) > index:
-            props[prop] = params[index]
+        if prop in props:
+            if isinstance(params, dict):
+                props[prop] = params.get(key or prop)
+            elif len(params) > index:
+                value = params[index]
+                if key and isinstance(value, dict):
+                    value = value.get(key)
+                props[prop] = value
         _LOGGER.debug('New miio props after setting %s(%s): %s', prop, params, props)
     return cbk
 
@@ -749,6 +755,119 @@ MIIO_TO_MIOT_SPECS = {
                 'set_callback': set_callback_via_param_index(0),
             },
             'prop.5.1': {'prop': 'illumination'},
+        },
+    },
+
+    'lumi.gateway.mitw01': {
+        # Taiwan Mi Control Hub. Uses the same packed rgb value as lumi.gateway.v3
+        # for light control, plus legacy miio props for guard/alarm, volume,
+        # doorbell, and night-light settings.
+        'miio_props': [
+            'rgb', 'illumination',
+            'arming', 'alarming_volume', 'arm_wait_time', 'alarm_time_len',
+            'en_alarm_light', 'doorbell_volume', 'gateway_volume',
+            'doorbell_push', 'night_light_rgb', 'corridor_light',
+        ],
+        'miio_specs': {
+            'prop.3.1': {
+                'prop': 'arming',
+                'setter': 'set_arming',
+                'template': '{{ value in ["on", "oning", "true", true, 1] }}',
+                'set_template': '{{ ["on" if value else "off"] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.3.2': {
+                'prop': 'alarming_volume',
+                'setter': 'set_alarming_volume',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.4.1': {
+                'prop': 'rgb',
+                'setter': 'set_rgb',
+                'template': '{{ value|int(0) > 0 }}',
+                'set_template': '{{ '
+                                '[ props.rgb|int(0) if props.rgb|int(0) > 0 else 1694498815 ] '
+                                'if value else [0] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.4.101': {
+                'prop': 'rgb',
+                'setter': 'set_rgb',
+                'template': '{{ (value|int(0) // 16777216) % 256 }}',
+                'set_template': '{{ '
+                                '[ value|int(100) * 16777216 '
+                                '+ ((props.rgb|int(0)) % 16777216 or 16777215) ] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.4.102': {
+                'prop': 'rgb',
+                'setter': 'set_rgb',
+                'template': '{{ value|int(0) % 16777216 }}',
+                'set_template': '{{ '
+                                '[ ((((props.rgb|int(0)) // 16777216) % 256) or 100) * 16777216 '
+                                '+ (value|int(0) % 16777216) ] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.5.1': {'prop': 'illumination'},
+            'prop.6.1': {
+                'prop': 'rgb',
+                'setter': 'set_rgb',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.2': {
+                'prop': 'night_light_rgb',
+                'setter': 'set_night_light_rgb',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.3': {
+                'prop': 'arm_wait_time',
+                'setter': 'set_arm_wait_time',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.4': {
+                'prop': 'alarm_time_len',
+                'setter': 'set_device_prop',
+                'set_template': '{{ {"method": "set_device_prop", "raw_params": true, "params": {"sid": "lumi.0", "alarm_time_len": value|int(0)}} }}',
+                'set_callback': set_callback_via_param_index(0, key='alarm_time_len'),
+            },
+            'prop.6.5': {
+                'prop': 'en_alarm_light',
+                # 0=always flash, 1=10 min, 2=1 min, 3=30 sec, 4=off,
+                # 5..59=custom seconds.
+                'setter': 'set_device_prop',
+                'set_template': '{{ {"method": "set_device_prop", "raw_params": true, "params": {"sid": "lumi.0", "en_alarm_light": value|int(0)}} }}',
+                'set_callback': set_callback_via_param_index(0, key='en_alarm_light'),
+            },
+            'prop.6.6': {
+                'prop': 'doorbell_volume',
+                'setter': 'set_doorbell_volume',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.7': {
+                'prop': 'gateway_volume',
+                'setter': 'set_gateway_volume',
+                'set_template': '{{ [value|int(0)] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.8': {
+                'prop': 'doorbell_push',
+                'setter': 'set_doorbell_push',
+                'template': '{{ value in ["on", "true", true, 1] }}',
+                'set_template': '{{ ["on" if value else "off"] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
+            'prop.6.9': {
+                'prop': 'corridor_light',
+                'setter': 'set_corridor_light',
+                'template': '{{ value in ["on", "true", true, 1] }}',
+                'set_template': '{{ ["on" if value else "off"] }}',
+                'set_callback': set_callback_via_param_index(0),
+            },
         },
     },
 

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -451,6 +451,130 @@
     }
   ],
 
+  "lumi.gateway.mitw01": [
+    {
+      "iid": 4,
+      "type": "urn:miot-spec-v2:service:light",
+      "properties": [
+        {
+          "iid": 101,
+          "type": "urn:miot-spec-v2:property:brightness",
+          "description": "Brightness",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "unit": "percentage",
+          "value-range": [1, 100, 1]
+        },
+        {
+          "iid": 102,
+          "type": "urn:miot-spec-v2:property:color",
+          "description": "Color",
+          "format": "uint32",
+          "access": ["read", "write"],
+          "unit": "rgb",
+          "value-range": [1, 16777215, 1]
+        }
+      ]
+    },
+    {
+      "iid": 5,
+      "type": "urn:miot-spec-v2:service:illumination-sensor",
+      "description": "Illumination Sensor",
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:illumination",
+          "description": "Illumination",
+          "format": "uint32",
+          "access": ["read"],
+          "unit": "lux",
+          "value-range": [0, 100000, 1]
+        }
+      ]
+    },
+    {
+      "iid": 6,
+      "type": "urn:miot-spec-v2:service:legacy-gateway",
+      "description": "Legacy Gateway",
+      "properties": [
+        {
+          "iid": 7,
+          "type": "urn:miot-spec-v2:property:gateway-volume",
+          "description": "Gateway Volume",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "unit": "percentage",
+          "value-range": [0, 100, 1]
+        },
+        {
+          "iid": 3,
+          "type": "urn:miot-spec-v2:property:arm-wait-time",
+          "description": "Arm Wait Time",
+          "format": "uint16",
+          "access": ["read", "write"],
+          "unit": "seconds",
+          "value-range": [0, 60, 1]
+        },
+        {
+          "iid": 4,
+          "type": "urn:miot-spec-v2:property:alarm-time-len",
+          "description": "Alarm Duration",
+          "format": "uint16",
+          "access": ["read", "write"],
+          "unit": "seconds",
+          "value-range": [0, 3600, 1]
+        },
+        {
+          "iid": 5,
+          "type": "urn:miot-spec-v2:property:en-alarm-light",
+          "description": "Alarm Light Duration",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "value-range": [0, 59, 1]
+        },
+        {
+          "iid": 8,
+          "type": "urn:miot-spec-v2:property:doorbell-push",
+          "description": "Doorbell Push",
+          "format": "bool",
+          "access": ["read", "write"]
+        },
+        {
+          "iid": 6,
+          "type": "urn:miot-spec-v2:property:doorbell-volume",
+          "description": "Doorbell Volume",
+          "format": "uint8",
+          "access": ["read", "write"],
+          "unit": "percentage",
+          "value-range": [0, 100, 1]
+        },
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:raw-rgb",
+          "description": "Raw RGB",
+          "format": "uint32",
+          "access": ["read", "write"],
+          "value-range": [0, 1694498815, 1]
+        },
+        {
+          "iid": 9,
+          "type": "urn:miot-spec-v2:property:corridor-light",
+          "description": "Corridor Light",
+          "format": "bool",
+          "access": ["read", "write"]
+        },
+        {
+          "iid": 2,
+          "type": "urn:miot-spec-v2:property:night-light-rgb",
+          "description": "Night Light RGB",
+          "format": "uint32",
+          "access": ["read", "write"],
+          "value-range": [0, 1694498815, 1]
+        }
+      ]
+    }
+  ],
+
   "lumi.motion.bmgl01": [
     {
       "iid": 2,


### PR DESCRIPTION
## Summary

- Add `lumi.gateway.mitw01` (Taiwan Mi Control Hub) miio2miot mappings for light on/off, brightness, color, illumination, guard/alarm, volume, doorbell, and night-light properties.
- Add extended MIOT spec entries for the hub's missing light brightness/color, illumination sensor, and legacy gateway properties.
- Allow miio2miot `set_template` output to opt into raw dict params so legacy `set_device_prop` calls can send `{ "sid": "lumi.0", ... }` without being wrapped in a list.
- Keep the miio props cache in sync when callbacks receive raw dict params.

## Testing

- `python3 -m py_compile custom_components/xiaomi_miot/core/miio2miot.py custom_components/xiaomi_miot/core/miio2miot_specs.py`
- Parsed `custom_components/xiaomi_miot/core/miot_specs_extend.json` and asserted `lumi.gateway.mitw01` contains light, illumination, and legacy gateway services.
- Imported `miio2miot_specs.py` directly and smoke-tested the new `set_callback_via_param_index(..., key=...)` path with raw dict params.
- Tested equivalent local patch on a real `lumi.gateway.mitw01` hub: `en_alarm_light` changed via Home Assistant `number.set_value`, direct local `get_device_prop` read back the changed value, then restored; `alarm_time_len` was tested the same way and restored.

## Notes

For this gateway, `alarm_time_len` and `en_alarm_light` are legacy miio device props. The working write form is:

```json
{"method": "set_device_prop", "params": {"sid": "lumi.0", "alarm_time_len": 30}}
```

Wrapping that dict in a list returns a params error, so this PR adds `raw_params` support for these mappings.
