### PR TITLE
fix(zhimi.fan.za5): restore horizontal_angle & off_delay number entities

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2961,7 +2961,7 @@ DEVICE_CUSTOMIZES = {
     },
     'zhimi.fan.za5': {
         **CHUNK_1,
-        'number_properties': 'speed_level',
+        'number_properties': 'speed_level,horizontal_angle,off_delay',
         'exclude_miot_properties': 'button_press,country_code',
         'interval_seconds': 121,
         'chunk_coordinators': [


### PR DESCRIPTION
### Problem

On `zhimi.fan.za5` (Smartmi Standing Fan) the **oscillation angle** (`horizontal_angle`) and **power-off delay** (`off_delay`) `number` entities are stuck `unavailable` and cannot be controlled.

### Root cause

The model-specific `zhimi.fan.za5` block sets:

```python
'number_properties': 'speed_level',
```

In `get_customize_via_model` the merge is per-key (`cfg = {**cus, **cfg}`), and the more specific `zhimi.fan.za5` entry wins over the `zhimi.fan.*` wildcard for the **whole** `number_properties` key. The wildcard value `horizontal_angle,vertical_angle,off_delay` is therefore dropped for the za5, so those properties are never turned into `number` entities.

The poll itself is fine — the za5 `chunk_coordinators` already fetch `horizontal_angle` and `off_delay`, and the values come back correctly (e.g. `siid=2/piid=5 swing-mode-angle = 90, code 0`). They are simply never decoded into entities because the names are missing from `number_properties`.

### Regression

This was introduced by #2622, which added `number_properties: 'speed_level'` to the za5 block. Before that the za5 inherited `horizontal_angle`/`off_delay` from the `zhimi.fan.*` wildcard (added in #1062) and angle control worked for ~2.5 years.

### Fix

Merge `speed_level` with the inherited angle/delay properties:

```python
'number_properties': 'speed_level,horizontal_angle,off_delay',
```

`vertical_angle` is intentionally omitted — it is not part of the za5 `chunk_coordinators` / spec.

### Verification

Tested live on a `zhimi.fan.za5`:

- after the change the `number.*_horizontal_angle` entity reads the real value (`90`) instead of `unavailable`
- setting it to `60` round-trips to the device (next poll reports `fan.horizontal_angle = 60`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)