### PR TITLE
Fix deprecated device_tracker.config_entry import (removed in HA 2027.6)

### DIFF
--- a/custom_components/xiaomi_miot/device_tracker.py
+++ b/custom_components/xiaomi_miot/device_tracker.py
@@ -5,12 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components.device_tracker import (
     DOMAIN as ENTITY_DOMAIN,
-)
-from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.components.device_tracker.config_entry import (
     TrackerEntity as BaseTrackerEntity,
     ScannerEntity as BaseScannerEntity,
 )
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (


### PR DESCRIPTION
## Summary

`TrackerEntity` and `ScannerEntity` are imported from `homeassistant.components.device_tracker.config_entry`, which Home Assistant core now exposes as **`DeprecatedAlias`** entries scheduled for removal in **HA Core 2027.6**. On every startup HA logs:

> The deprecated alias `TrackerEntity` was used from `xiaomi_miot`. It will be removed in HA Core 2027.6. Use `homeassistant.components.device_tracker.TrackerEntity` instead.

## Change

Import `TrackerEntity` and `ScannerEntity` from the `device_tracker` package **root** instead of the deprecated `config_entry` submodule:

```diff
 from homeassistant.components.device_tracker import (
     DOMAIN as ENTITY_DOMAIN,
+    TrackerEntity as BaseTrackerEntity,
+    ScannerEntity as BaseScannerEntity,
 )
 from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.components.device_tracker.config_entry import (
-    TrackerEntity as BaseTrackerEntity,
-    ScannerEntity as BaseScannerEntity,
-)
```

Same classes, **no behavioural change** — only the import path is updated to the non-deprecated location. The root re-export has been stable for a long time, so this is safe across supported HA versions.

## Testing

- `python -m py_compile` -> OK
- **Live HA instance**: `ha core check` passes; after restart the `xiaomi_miot` config entry loads, all entities remain present, and the `TrackerEntity` deprecation warning no longer appears.