### PR TITLE
Add fan direction controls

### DIFF
--- a/custom_components/xiaomi_miot/fan.py
+++ b/custom_components/xiaomi_miot/fan.py
@@ -71,6 +71,9 @@ class FanEntity(XEntity, BaseEntity):
     _conv_oscillate = None
     _act_turn_left = None
     _act_turn_right = None
+    _prop_direction = None
+    _direction_left = None
+    _direction_right = None
     _prop_speed = None
     _prop_percentage = None
 
@@ -113,6 +116,16 @@ class FanEntity(XEntity, BaseEntity):
             else:
                 self._act_turn_left = None
                 self._act_turn_right = None
+                for prop in self._miot_service.spec.get_properties('motor_control'):
+                    left = prop.list_first('left')
+                    right = prop.list_first('right')
+                    if not prop.writeable or left is None or right is None:
+                        continue
+                    self._prop_direction = prop
+                    self._direction_left = left
+                    self._direction_right = right
+                    self._attr_supported_features |= FanEntityFeature.DIRECTION
+                    break
 
         # issues/617
         if self.custom_config_bool('disable_preset_modes'):
@@ -239,17 +252,20 @@ class FanEntity(XEntity, BaseEntity):
         await self.device.async_write({self._conv_oscillate.full_name: oscillating})
 
     async def async_set_direction(self, direction: str):
-        action = {
-            DIRECTION_REVERSE: self._act_turn_left,
-            DIRECTION_FORWARD: self._act_turn_right,
-            'left': self._act_turn_left,
-            'right': self._act_turn_right,
-        }.get(direction)
-        if not action:
+        if direction in [DIRECTION_REVERSE, 'left']:
+            action = self._act_turn_left
+            value = self._direction_left
+        elif direction in [DIRECTION_FORWARD, 'right']:
+            action = self._act_turn_right
+            value = self._direction_right
+        else:
             return
         if self._conv_oscillate and self._attr_oscillating:
             await self.async_oscillate(False)
-        return await self.async_call_action(action)
+        if action:
+            return await self.async_call_action(action)
+        if self._prop_direction:
+            return await self.async_set_property(self._prop_direction, value)
 
 
 XEntity.CLS[ENTITY_DOMAIN] = FanEntity

--- a/custom_components/xiaomi_miot/fan.py
+++ b/custom_components/xiaomi_miot/fan.py
@@ -4,6 +4,8 @@ from homeassistant.helpers.event import async_call_later
 
 from homeassistant.components.fan import (
     DOMAIN as ENTITY_DOMAIN,
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
     FanEntity as BaseEntity,
     FanEntityFeature,
 )
@@ -67,6 +69,8 @@ class FanEntity(XEntity, BaseEntity):
     _speed_list = None
     _speed_range = None
     _conv_oscillate = None
+    _act_turn_left = None
+    _act_turn_right = None
     _prop_speed = None
     _prop_percentage = None
 
@@ -99,6 +103,16 @@ class FanEntity(XEntity, BaseEntity):
             elif prop.in_list(['horizontal_swing', 'vertical_swing']) and not self._conv_oscillate:
                 self._conv_oscillate = conv
                 self._attr_supported_features |= FanEntityFeature.OSCILLATE
+
+        if self._miot_service:
+            self._act_turn_left = self._miot_service.get_action('turn_left')
+            self._act_turn_right = self._miot_service.get_action('turn_right')
+            direction_actions = (self._act_turn_left, self._act_turn_right)
+            if all(action and not action.ins for action in direction_actions):
+                self._attr_supported_features |= FanEntityFeature.DIRECTION
+            else:
+                self._act_turn_left = None
+                self._act_turn_right = None
 
         # issues/617
         if self.custom_config_bool('disable_preset_modes'):
@@ -223,6 +237,19 @@ class FanEntity(XEntity, BaseEntity):
         if not self._conv_oscillate:
             return
         await self.device.async_write({self._conv_oscillate.full_name: oscillating})
+
+    async def async_set_direction(self, direction: str):
+        action = {
+            DIRECTION_REVERSE: self._act_turn_left,
+            DIRECTION_FORWARD: self._act_turn_right,
+            'left': self._act_turn_left,
+            'right': self._act_turn_right,
+        }.get(direction)
+        if not action:
+            return
+        if self._conv_oscillate and self._attr_oscillating:
+            await self.async_oscillate(False)
+        return await self.async_call_action(action)
 
 
 XEntity.CLS[ENTITY_DOMAIN] = FanEntity


### PR DESCRIPTION
## Summary

- expose Home Assistant's native fan direction feature when a MIoT fan provides either parameterless `turn-left`/`turn-right` actions or a writable `motor-control` property with LEFT/RIGHT values
- map `reverse`/`left` and `forward`/`right` to the corresponding MIoT action or property value
- stop active oscillation before a manual direction step, matching the Xiaomi Miio integration

## Why

The converter-based MIoT fan entity detects power, speed, preset, and oscillation properties, but ignores direction actions and left/right motor-control properties. As a result, supported Xiaomi fans lose the left/right controls available through Home Assistant's Xiaomi Miio integration.

## Impact

Compatible fans now expose `FanEntityFeature.DIRECTION` and work with Home Assistant's `fan.set_direction` action. Native direction actions take precedence over the motor-control fallback. Fans without either complete capability remain unchanged, and existing standalone button, select, and cover entities remain available.

## Validation

- compiled `custom_components/xiaomi_miot` with `python3 -m compileall`
- exercised action and motor-control detection, left/right mapping, oscillation shutdown, and unsupported-input behavior with a targeted async harness
- ran `ha core check` and tested on Home Assistant Core 2026.7.0
- confirmed both action-based direction calls on `xiaomi.fan.p45` returned MIoT code `0`
- confirmed LEFT and RIGHT motor-control writes on `dmaker.fan.p33` returned MIoT code `0`
- checked the committed diff with `git show --check`
