### PR TITLE
Handle invalid XiaoAI conversation data

### DIFF
--- a/custom_components/xiaomi_miot/sensor.py
+++ b/custom_components/xiaomi_miot/sensor.py
@@ -597,9 +597,13 @@ class XiaoaiConversationSensor(MiCoordinatorEntity, BaseSensorSubEntity):
         }
         try:
             res = await mic.async_request_api(api, data=dat, method='GET', cookies=cks) or {}
-            rdt = res.get('data', {})
-            if not isinstance(rdt, dict):
+            rdt = res.get('data')
+            if rdt is None:
+                return {}
+            if isinstance(rdt, (str, bytes, bytearray)):
                 rdt = json.loads(rdt) or {}
+            if not isinstance(rdt, dict):
+                return {}
         except (TypeError, ValueError, Exception) as exc:
             rdt = {}
             _LOGGER.warning(

--- a/tests/test_xiaoai_conversation_sensor.py
+++ b/tests/test_xiaoai_conversation_sensor.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.xiaomi_miot import sensor as sensor_module
+from custom_components.xiaomi_miot.sensor import XiaoaiConversationSensor
+
+
+@pytest.mark.parametrize('response_data', [None, []])
+async def test_invalid_response_data_keeps_last_conversation(monkeypatch, response_data):
+    class FakeMiotCloud:
+        async_request_api = AsyncMock(return_value={'data': response_data})
+
+    monkeypatch.setattr(sensor_module, 'MiotCloud', FakeMiotCloud)
+    previous = {
+        'content': 'turn off the computer',
+        'answers': [],
+        'history': [],
+        'timestamp': None,
+    }
+    sensor = XiaoaiConversationSensor.__new__(XiaoaiConversationSensor)
+    sensor._parent = SimpleNamespace(
+        xiaoai_cloud=FakeMiotCloud(),
+        xiaoai_device={'deviceID': 'test-device', 'hardware': 'test-hardware'},
+        device_name='Test Speaker',
+    )
+    sensor._model = 'test.speaker'
+    sensor._available = True
+    sensor._attr_native_value = previous['content']
+    sensor._state_attrs = previous.copy()
+    sensor.conversation = {'query': previous['content']}
+
+    result = await sensor.fetch_latest_message()
+
+    assert result == {}
+    assert sensor._attr_native_value == previous['content']
+    assert sensor._state_attrs == previous
+    assert sensor.conversation == {'query': previous['content']}


### PR DESCRIPTION
## Summary

- Treat null or unexpected Mina conversation `data` payloads as no update.
- Preserve the last valid conversation and its attributes.
- Add regression coverage for null and non-dict payloads.

## Problem

The Mina conversation endpoint may intermittently return `data: null`.
The sensor currently attempts to call `json.loads(None)`, logs a
`TypeError` for the affected poll, and replaces the current conversation
attributes with empty values.

## Tests

- `python -m pytest -q tests/test_xiaoai_conversation_sensor.py`
  - 2 passed

Fixes #2802
