### PR TITLE
Make release asset publishing reliable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      ASSET_PATH: ${{ runner.temp }}/xiaomi_miot.zip
+      ASSET_PATH: ${{ github.workspace }}/xiaomi_miot.zip
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - name: Checkout the released tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          archive_mtime="$(git show -s --format=%ct HEAD)"
           git archive \
             --format=zip \
+            --mtime="@${archive_mtime}" \
             --output="${ASSET_PATH}" \
             HEAD:custom_components/xiaomi_miot
           unzip -t "${ASSET_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,69 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to rebuild
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
   release-zip:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      ASSET_PATH: ${{ runner.temp }}/xiaomi_miot.zip
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: ZIP Component Dir
-        run: |
-          cd ${{ github.workspace }}/custom_components/xiaomi_miot
-          zip -r xiaomi_miot.zip ./
-
-      - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v2
+      - name: Checkout the released tag
+        uses: actions/checkout@v4
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/custom_components/xiaomi_miot/xiaomi_miot.zip
-          asset_name: xiaomi_miot.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          persist-credentials: false
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest_version="$(
+            python3 -c \
+              'import json; print(json.load(open("custom_components/xiaomi_miot/manifest.json"))["version"])'
+          )"
+          if [[ "${RELEASE_TAG}" != "v${manifest_version}" ]]; then
+            echo "::error::Release tag ${RELEASE_TAG} does not match manifest version ${manifest_version}"
+            exit 1
+          fi
+
+      - name: Build and verify release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          git archive \
+            --format=zip \
+            --output="${ASSET_PATH}" \
+            HEAD:custom_components/xiaomi_miot
+          unzip -t "${ASSET_PATH}"
+          (
+            cd "$(dirname "${ASSET_PATH}")"
+            sha256sum "$(basename "${ASSET_PATH}")" \
+              > "$(basename "${ASSET_PATH}").sha256"
+          )
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            "${ASSET_PATH}" \
+            "${ASSET_PATH}.sha256" \
+            --clobber \
+            --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Problem

The release workflow relies on the repository default `GITHUB_TOKEN` permissions and a third-party upload action. Repositories using GitHub's restricted default token can build `xiaomi_miot.zip`, but the upload step fails with:

```text
Resource not accessible by integration
```

The current `zip -r ./` command also packages the mutable checkout directory and does not verify that the release tag matches the integration version.

## Solution

- Grant only the release job `contents: write`, which is required to upload release assets.
- Check out the exact released tag with persisted checkout credentials disabled.
- Fail before packaging when `v<manifest version>` does not match the release tag.
- Build `xiaomi_miot.zip` from tracked files with `git archive`.
- Pin every ZIP entry timestamp to the released commit timestamp so repeated builds are byte-for-byte reproducible.
- Verify the ZIP and publish a SHA-256 checksum.
- Use the GitHub CLI already installed on hosted runners instead of a third-party upload action.
- Add `workflow_dispatch` with an existing tag input so a failed asset build can be safely retried.
- Serialize builds for the same release tag and cap the job at five minutes.

## Security

`contents: write` is scoped to the single release job. Other workflows and jobs retain their existing permissions. Release values are passed through environment variables rather than interpolated directly into shell commands.

## Validation

- Workflow YAML parsed locally.
- Tag/manifest validation passed for `v1.1.4`.
- Two archives generated from the same commit and fixed timestamp had identical SHA-256 hashes.
- The archive passed `unzip -t`.
- The archive contained no `.git`, tests, `__pycache__`, or nested release ZIP.
- Full Fork validation passed on the final commit: [Validate #30427705036](https://github.com/Wuty-zju/hass-xiaomi-miot/actions/runs/30427705036).
- Two independent end-to-end rebuilds of `v1.1.5-wuty.4` uploaded a byte-identical ZIP with SHA-256 `f626e3e33055d139ff0884da8d8bf411ee95d023d78c833245237d41b38a7d35`: [run 1](https://github.com/Wuty-zju/hass-xiaomi-miot/actions/runs/30427981270), [run 2](https://github.com/Wuty-zju/hass-xiaomi-miot/actions/runs/30428012923).
