### PR TITLE
Expose Xiaomi Home manual scenes as buttons

### DIFF
--- a/custom_components/xiaomi_miot/button.py
+++ b/custom_components/xiaomi_miot/button.py
@@ -1,10 +1,13 @@
 """Support button entity for Xiaomi Miot."""
+from collections import Counter
 import logging
 
 from homeassistant.components.button import (
     DOMAIN as ENTITY_DOMAIN,
     ButtonEntity as BaseEntity,
 )
+from homeassistant.const import CONF_USERNAME
+from homeassistant.exceptions import HomeAssistantError
 
 from . import (
     DOMAIN,
@@ -15,6 +18,7 @@ from . import (
     async_setup_config_entry,
 )
 from .core.templates import template
+from .core.xiaomi_cloud import MiCloudException
 
 _LOGGER = logging.getLogger(__name__)
 DATA_KEY = f'{ENTITY_DOMAIN}.{DOMAIN}'
@@ -23,8 +27,29 @@ SERVICE_TO_METHOD = {}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    HassEntry.init(hass, config_entry).new_adder(ENTITY_DOMAIN, async_add_entities)
+    entry = HassEntry.init(hass, config_entry)
+    entry.new_adder(ENTITY_DOMAIN, async_add_entities)
     await async_setup_config_entry(hass, config_entry, async_setup_platform, async_add_entities, ENTITY_DOMAIN)
+    if not entry.get_config(CONF_USERNAME) or not entry.cloud:
+        return
+    try:
+        scenes = await entry.cloud.async_get_manual_scenes()
+    except MiCloudException as exc:
+        _LOGGER.warning('Unable to get Xiaomi Home manual scenes: %s', exc)
+        return
+    names = Counter(scene['scene_name'] for scene in scenes)
+    async_add_entities([
+        ManualSceneButton(
+            entry.cloud,
+            scene,
+            (
+                f'{scene["home_name"]} {scene["scene_name"]}'
+                if names[scene['scene_name']] > 1 and scene['home_name']
+                else scene['scene_name']
+            ),
+        )
+        for scene in scenes
+    ])
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -56,6 +81,41 @@ class ButtonEntity(XEntity, BaseEntity):
 
 
 XEntity.CLS[ENTITY_DOMAIN] = ButtonEntity
+
+
+class ManualSceneButton(BaseEntity):
+    _attr_has_entity_name = True
+    _attr_icon = 'mdi:play'
+
+    def __init__(self, cloud, scene, name):
+        self.cloud = cloud
+        self.scene = scene
+        self._attr_name = name
+        self._attr_unique_id = (
+            f'{cloud.unique_id}-manual-scene-'
+            f'{scene["home_id"]}-{scene["scene_id"]}'
+        )
+        self._attr_device_info = {
+            'identifiers': {(DOMAIN, f'{cloud.unique_id}-manual-scenes')},
+            'name': 'Xiaomi Home Scenes',
+            'manufacturer': 'Xiaomi',
+            'model': 'Manual scenes',
+        }
+        self._attr_extra_state_attributes = {
+            'home_name': scene.get('home_name') or None,
+        }
+
+    async def async_press(self):
+        try:
+            success = await self.cloud.async_run_manual_scene(self.scene)
+        except MiCloudException as exc:
+            raise HomeAssistantError(
+                f'Unable to run Xiaomi Home scene: {self.name}'
+            ) from exc
+        if not success:
+            raise HomeAssistantError(
+                f'Unable to run Xiaomi Home scene: {self.name}'
+            )
 
 
 class ButtonSubEntity(BaseEntity, BaseSubEntity):

--- a/custom_components/xiaomi_miot/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_miot/core/xiaomi_cloud.py
@@ -62,6 +62,7 @@ _LOGGER.addFilter(logger_filter)
 
 ACCOUNT_BASE = 'https://account.xiaomi.com'
 UA = "Android-7.1.1-1.0.0-ONEPLUS A3010-136-%s APP/xiaomi.smarthome APPV/62830"
+MANUAL_SCENE_API = 'appgateway/miot/appsceneservice/AppSceneService'
 
 
 class MiotCloud(micloud.MiCloud):
@@ -545,6 +546,66 @@ class MiotCloud(micloud.MiCloud):
     async def async_get_homerooms(self, renew=False):
         dat = await self.async_get_devices(renew=renew, return_all=True) or {}
         return dat.get('homes') or []
+
+    async def _async_request_manual_scene_api(self, method, data):
+        api = f'{MANUAL_SCENE_API}/{method}'
+        rdt = await self.async_request_api(api, data, debug=False, timeout=20) or {}
+        if self.is_token_expired(rdt):
+            if await self.async_check_auth(notify=True):
+                rdt = await self.async_request_api(api, data, debug=False, timeout=20) or {}
+        if rdt.get('code') or 'result' not in rdt:
+            raise MiCloudException(
+                f'Xiaomi manual scene request failed: '
+                f'{rdt.get("code")}, {rdt.get("message") or "invalid response"}'
+            )
+        return rdt['result']
+
+    async def async_get_manual_scenes(self):
+        scenes = []
+        for home in await self.async_get_homerooms():
+            home_id = home.get('id')
+            owner_uid = home.get('uid') or self.user_id
+            if not home_id or not owner_uid:
+                continue
+            result = await self._async_request_manual_scene_api(
+                'GetManualSceneList',
+                {
+                    'home_id': str(home_id),
+                    'owner_uid': str(owner_uid),
+                    'source': 'zkp',
+                    'get_type': 2,
+                },
+            )
+            if not isinstance(result, list):
+                raise MiCloudException('Xiaomi manual scene list is invalid')
+            for scene in result:
+                if not isinstance(scene, dict):
+                    continue
+                scene_id = scene.get('scene_id')
+                scene_name = scene.get('scene_name')
+                if scene_id is None or not scene_name:
+                    continue
+                scenes.append({
+                    **scene,
+                    'scene_id': str(scene_id),
+                    'home_id': str(home_id),
+                    'home_name': home.get('name') or '',
+                    'owner_uid': str(owner_uid),
+                })
+        return scenes
+
+    async def async_run_manual_scene(self, scene):
+        data = {
+            'owner_uid': scene['owner_uid'],
+            'scene_id': scene['scene_id'],
+            'scene_type': 2,
+        }
+        if home_id := scene.get('home_id'):
+            data['home_id'] = home_id
+        if room_id := scene.get('room_id'):
+            data['room_id'] = room_id
+        result = await self._async_request_manual_scene_api('NewRunScene', data)
+        return bool(result)
 
     async def async_get_beaconkey(self, did):
         dat = {'did': did, 'pdid': 1}

--- a/tests/test_manual_scenes.py
+++ b/tests/test_manual_scenes.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.xiaomi_miot import DOMAIN
+from custom_components.xiaomi_miot.button import ManualSceneButton
+from custom_components.xiaomi_miot.core.xiaomi_cloud import MiotCloud
+
+
+async def test_get_manual_scenes_from_all_homes():
+    cloud = MiotCloud.__new__(MiotCloud)
+    cloud.user_id = '1000'
+    cloud.async_get_homerooms = AsyncMock(return_value=[
+        {'id': '1', 'uid': '1000', 'name': 'Home'},
+        {'id': '2', 'uid': '2000', 'name': 'Shared home'},
+    ])
+    cloud._async_request_manual_scene_api = AsyncMock(side_effect=[
+        [{'scene_id': 11, 'scene_name': 'Sleep'}],
+        [{'scene_id': '22', 'scene_name': 'Work', 'room_id': '3'}],
+    ])
+
+    scenes = await cloud.async_get_manual_scenes()
+
+    assert scenes == [
+        {
+            'scene_id': '11',
+            'scene_name': 'Sleep',
+            'home_id': '1',
+            'home_name': 'Home',
+            'owner_uid': '1000',
+        },
+        {
+            'scene_id': '22',
+            'scene_name': 'Work',
+            'room_id': '3',
+            'home_id': '2',
+            'home_name': 'Shared home',
+            'owner_uid': '2000',
+        },
+    ]
+
+
+async def test_run_manual_scene_uses_scene_owner_and_scope():
+    cloud = MiotCloud.__new__(MiotCloud)
+    cloud._async_request_manual_scene_api = AsyncMock(return_value=True)
+
+    result = await cloud.async_run_manual_scene({
+        'owner_uid': '1000',
+        'scene_id': '11',
+        'home_id': '1',
+        'room_id': '3',
+    })
+
+    assert result is True
+    cloud._async_request_manual_scene_api.assert_awaited_once_with(
+        'NewRunScene',
+        {
+            'owner_uid': '1000',
+            'scene_id': '11',
+            'scene_type': 2,
+            'home_id': '1',
+            'room_id': '3',
+        },
+    )
+
+
+async def test_manual_scene_buttons_share_one_device():
+    cloud = SimpleNamespace(
+        unique_id='1000-cn-xiaomiio',
+        async_run_manual_scene=AsyncMock(return_value=True),
+    )
+    first = ManualSceneButton(cloud, {
+        'owner_uid': '1000',
+        'scene_id': '11',
+        'scene_name': 'Sleep',
+        'home_id': '1',
+        'home_name': 'Home',
+    }, 'Sleep')
+    second = ManualSceneButton(cloud, {
+        'owner_uid': '1000',
+        'scene_id': '22',
+        'scene_name': 'Work',
+        'home_id': '1',
+        'home_name': 'Home',
+    }, 'Work')
+
+    assert first.device_info['identifiers'] == second.device_info['identifiers']
+    assert first.device_info['identifiers'] == {
+        (DOMAIN, '1000-cn-xiaomiio-manual-scenes')
+    }
+
+    await first.async_press()
+    cloud.async_run_manual_scene.assert_awaited_once_with(first.scene)
+
+
+async def test_manual_scene_button_reports_failed_execution():
+    cloud = SimpleNamespace(
+        unique_id='1000-cn-xiaomiio',
+        async_run_manual_scene=AsyncMock(return_value=False),
+    )
+    button = ManualSceneButton(cloud, {
+        'owner_uid': '1000',
+        'scene_id': '11',
+        'scene_name': 'Sleep',
+        'home_id': '1',
+        'home_name': 'Home',
+    }, 'Sleep')
+
+    with pytest.raises(HomeAssistantError):
+        await button.async_press()


### PR DESCRIPTION
## Problem

Xiaomi Home manual scenes can currently be viewed and triggered through applications such as Miloco, but Xiaomi Miot does not expose them as Home Assistant entities.

## Approach

This adds the smallest account-level bridge on top of the existing Xiaomi Miot cloud session:

- fetch manual scenes for each account home from `AppSceneService/GetManualSceneList`;
- expose every scene as a Home Assistant button;
- group all buttons from one Xiaomi account under one virtual `Xiaomi Home Scenes` device;
- execute a pressed button through `AppSceneService/NewRunScene`;
- reuse the integration existing service-token authentication, auth retry, account region and cached home metadata.

No Miloco service, OAuth token, database, new dependency, polling coordinator or MIoT device customization is required. Scene additions, deletions and renames are picked up when the config entry is reloaded.

Duplicate scene names are prefixed with their home name. Unique IDs include the account, home and scene IDs.

## Authentication note

Miloco uses Xiaomi Home OAuth Bearer authentication, while this integration uses its existing `serviceToken`/`ssecurity` request signing. They are not interchangeable tokens, but both address the same account-, region- and home-scoped AppSceneService. The existing Xiaomi Miot session was verified read-only against the endpoint with 11 manual scenes across two homes.

## Tests

- scene discovery across owned and shared homes;
- execution payload and optional home/room scope;
- all scene buttons share one device identifier;
- failed execution is surfaced as a Home Assistant error;
- full repository pytest: 174 passed;
- Fork CI: stable/minimum pytest, Hassfest, HACS, and Home Assistant stable/dev/minimum validation passed.

No physical scene was executed during validation to avoid changing real devices.