### PR TITLE
Fix deprecated concentration constants

### DIFF
--- a/custom_components/xiaomi_miot/core/const.py
+++ b/custom_components/xiaomi_miot/core/const.py
@@ -113,3 +113,16 @@ except (ModuleNotFoundError, ImportError):
         DOCKED = "docked"
         RETURNING = "returning"
         ERROR = "error"
+
+try:
+    # hass 2026.7
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+except (ModuleNotFoundError, ImportError):
+    class UnitOfDensity(StrEnum):
+        """Density units."""
+        MILLIGRAMS_PER_CUBIC_METER = "mg/m³"
+        MICROGRAMS_PER_CUBIC_METER = "μg/m³"
+
+    class UnitOfRatio(StrEnum):
+        """Ratio units."""
+        PARTS_PER_MILLION = "ppm"

--- a/custom_components/xiaomi_miot/core/miot_spec.py
+++ b/custom_components/xiaomi_miot/core/miot_spec.py
@@ -9,10 +9,6 @@ from collections.abc import Iterable
 
 from homeassistant.core import HomeAssistant
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
     UnitOfElectricCurrent,
@@ -32,6 +28,8 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import (
     DOMAIN,
     TRANSLATION_LANGUAGES,
+    UnitOfDensity,
+    UnitOfRatio,
 )
 from .utils import get_translation_langs, convert_globs_to_pattern
 
@@ -950,9 +948,9 @@ class MiotProperty(MiotSpecInstance):
             'lux': LIGHT_LUX,
             'watt': UnitOfPower.WATT,
             'pascal': UnitOfPressure.PA,
-            'μg/m3': CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-            'mg/m3': CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-            'p/m3': CONCENTRATION_PARTS_PER_CUBIC_METER,
+            'μg/m3': UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+            'mg/m3': UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER,
+            'p/m3': 'p/m³',
         }
         names = {
             'current_step_count': 'steps',
@@ -960,9 +958,9 @@ class MiotProperty(MiotSpecInstance):
             'power_consumption': UnitOfEnergy.WATT_HOUR,
             'electric_current': UnitOfElectricCurrent.AMPERE,
             'voltage': UnitOfElectricPotential.VOLT,
-            'pm2_5_density': CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-            'tds_in': CONCENTRATION_PARTS_PER_MILLION,
-            'tds_out': CONCENTRATION_PARTS_PER_MILLION,
+            'pm2_5_density': UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+            'tds_in': UnitOfRatio.PARTS_PER_MILLION,
+            'tds_out': UnitOfRatio.PARTS_PER_MILLION,
         }
         if unit in aliases:
             unit = aliases[unit]

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,7 @@
+from custom_components.xiaomi_miot.core.const import UnitOfDensity, UnitOfRatio
+
+
+def test_concentration_unit_compatibility():
+    assert UnitOfDensity.MICROGRAMS_PER_CUBIC_METER == "μg/m³"
+    assert UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER == "mg/m³"
+    assert UnitOfRatio.PARTS_PER_MILLION == "ppm"


### PR DESCRIPTION
Fixes #2905.

Partially addresses #2870 and #2897.

## What changed

- Use `UnitOfDensity` and `UnitOfRatio` for concentration units on Home Assistant 2026.7 and newer.
- Define matching local `StrEnum` fallbacks in `core/const.py` for older supported Home Assistant versions.
- Replace `CONCENTRATION_PARTS_PER_CUBIC_METER` with its recommended `p/m³` literal.
- Add unit assertions that run in both the stable and minimum-version test jobs.

## Why

Home Assistant 2026.8 deprecated the four `CONCENTRATION_*` constants used by `miot_spec.py`, which emits warnings whenever the integration is imported.

`UnitOfDensity` and `UnitOfRatio` were introduced in Home Assistant 2026.7, while this repository declares and tests Home Assistant 2025.6.0 as its minimum. The compatibility definitions preserve that existing minimum rather than requiring it to be raised.

Home Assistant references:

- Density enum: https://github.com/home-assistant/core/commit/faa3a4ddef57cc6b07b6ada38303f450f2a575b6
- Ratio enum: https://github.com/home-assistant/core/commit/687064d5cc4ac648e403505beec3a6af1d93239b
- Concentration deprecations: https://github.com/home-assistant/core/commit/d1275c1128030cca53d16beafaed61d3c5a8a92f

## Validation

- Compiled the integration with `python -m compileall`.
- Imported `core.const` and `core.miot_spec` on Home Assistant 2026.8.0b2 without concentration deprecation warnings.
- Exercised the pre-2026.7 fallback path in isolation and verified `μg/m³`, `mg/m³`, and `ppm`.
- The repository CI matrix will run the added assertions against stable Home Assistant and the declared 2025.6.0 minimum.
