### PR TITLE
Remove deprecated device tracker properties

### DIFF
--- a/custom_components/xiaomi_miot/config_flow.py
+++ b/custom_components/xiaomi_miot/config_flow.py
@@ -1260,7 +1260,6 @@ def get_customize_options(hass, options={}, bool2selects=[], entity_id='', model
         options.update({
             'coord_type': cv.string,
         })
-        bool2selects.extend(['disable_location_name'])
 
     if re.search(r'sensor_occupy', model, re.I):
         options.update({

--- a/custom_components/xiaomi_miot/device_tracker.py
+++ b/custom_components/xiaomi_miot/device_tracker.py
@@ -92,16 +92,10 @@ XEntity.CLS['scanner'] = ScannerEntity
 class MiotTrackerEntity(MiotEntity, BaseTrackerEntity):
     _attr_latitude = None
     _attr_longitude = None
-    _attr_location_name = None
     _attr_location_accuracy = 0
-    _disable_location_name = False
 
     def __init__(self, config, miot_service: MiotService = None):
         super().__init__(miot_service, config=config, logger=_LOGGER)
-
-    async def async_added_to_hass(self):
-        await super().async_added_to_hass()
-        self._disable_location_name = self.custom_config_bool('disable_location_name')
 
     async def async_update(self):
         await super().async_update()
@@ -113,7 +107,7 @@ class MiotTrackerEntity(MiotEntity, BaseTrackerEntity):
         if prop := self._miot_service.get_property('longitude'):
             self._attr_longitude = prop.from_device(self.device)
         if prop := self._miot_service.get_property('current_address'):
-            self._attr_location_name = prop.from_device(self.device)
+            self.update_attrs({'current_address': prop.from_device(self.device)})
         await self.transform_coord()
 
     async def transform_coord(self, default=None):
@@ -149,30 +143,11 @@ class MiotTrackerEntity(MiotEntity, BaseTrackerEntity):
         return self._attr_longitude
 
     @property
-    def location_name(self):
-        """Return a location name for the current location of the device."""
-        if self._disable_location_name:
-            return None
-        return self._attr_location_name
-
-    @property
     def location_accuracy(self):
         """Return the location accuracy of the device.
         Value in meters.
         """
         return self._attr_location_accuracy
-
-    @property
-    def battery_level(self):
-        """Return the battery level of the device."""
-        if not self._miot_service:
-            return None
-        sls = [self._miot_service, *self._miot_service.spec.get_services('battery')]
-        for srv in sls:
-            prop = srv.get_property('battery_level')
-            if prop:
-                return prop.from_device(self.device)
-        return None
 
 
 class XiaoxunWatchTrackerEntity(MiotTrackerEntity):
@@ -223,7 +198,7 @@ class XiaoxunWatchTrackerEntity(MiotTrackerEntity):
         gps = f"{loc.get('location', '')},".split(',')
         self._attr_latitude = float(gps[1])
         self._attr_longitude = float(gps[0])
-        self._attr_location_name = loc.get('desc')
+        self.update_attrs({'current_address': loc.get('desc')})
         self._attr_location_accuracy = int(loc.get('radius') or 0)
         await self.transform_coord(default='gcj02')
         self.update_attrs({

--- a/custom_components/xiaomi_miot/translations/en.json
+++ b/custom_components/xiaomi_miot/translations/en.json
@@ -83,7 +83,6 @@
                     "deviated_position": "deviated_position",
                     "device_class": "device_class",
                     "diagnostic_entities": "diagnostic_entities",
-                    "disable_location_name": "disable_location_name",
                     "disable_preset_modes": "disable_preset_modes",
                     "entity_category": "entity_category",
                     "exclude_miot_properties": "exclude_miot_properties",

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,7 @@
+from custom_components.xiaomi_miot.device_tracker import MiotTrackerEntity
+
+
+def test_tracker_does_not_override_deprecated_properties():
+    assert "battery_level" not in MiotTrackerEntity.__dict__
+    assert "location_name" not in MiotTrackerEntity.__dict__
+    assert "_attr_location_name" not in MiotTrackerEntity.__dict__


### PR DESCRIPTION
Fixes #2908.

Related to #2870 and #2897, which also track other deprecations and domain problems not addressed here.

## What changed

- Remove the deprecated `MiotTrackerEntity.battery_level` override; battery data remains available through the integration's dedicated battery sensor entities.
- Remove the deprecated `location_name` override and stop setting `_attr_location_name`, so Home Assistant derives tracker state from coordinates and configured zones.
- Preserve Xiaomi's human-readable location as the `current_address` extra state attribute.
- Remove the now-obsolete `disable_location_name` customization and its translation.
- Add a regression test that rejects both deprecated overrides and `_attr_location_name`.

## Why

Home Assistant 2026.7 added warnings for custom tracker entities that override `battery_level` or `location_name`; these APIs become unsupported in Home Assistant 2027.7. `MiotTrackerEntity` implemented both legacy properties, and Xiaoxun trackers also assigned `_attr_location_name` directly.

This follows Home Assistant's current tracker model: battery percentage belongs in a sensor entity, while a GPS tracker state is resolved from latitude/longitude and zones rather than an integration-supplied free-form address.

Home Assistant references:

- https://github.com/home-assistant/core/pull/171819
- https://github.com/home-assistant/core/pull/171820

## Validation

- `python -m compileall -q custom_components tests`
- `python -m json.tool custom_components/xiaomi_miot/translations/en.json`
- Imported the patched component in Home Assistant 2026.8.0b2 without either tracker deprecation warning.
- Ran `python -m pytest -q /tmp/test_device_tracker.py` against the patched component in that Home Assistant environment: `1 passed`.