### PR TITLE
Add capability-based room cleaning for MIoT vacuums

### DIFF
--- a/custom_components/xiaomi_miot/vacuum.py
+++ b/custom_components/xiaomi_miot/vacuum.py
@@ -1,11 +1,13 @@
 """Support for Xiaomi vacuums."""
 import logging
 import asyncio
+import json
 from datetime import timedelta
 
 from homeassistant.components.vacuum import (  # noqa: F401
     DOMAIN as ENTITY_DOMAIN,
     StateVacuumEntity,
+    Segment,
     VacuumEntityFeature,  # v2022.5
 )
 from .core.const import VacuumActivity
@@ -68,6 +70,10 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
 
     def __init__(self, config: dict, miot_service: MiotService):
         super().__init__(miot_service, config=config, logger=_LOGGER)
+        # MiotEntity defaults generated IDs to the integration domain.  Vacuum
+        # entities must retain the platform domain, especially on a fresh
+        # entity registry after another vacuum integration is removed.
+        self.entity_id = miot_service.generate_entity_id(self, domain=ENTITY_DOMAIN)
 
         self._prop_power = miot_service.get_property('on', 'power')
         self._prop_status = miot_service.get_property('status')
@@ -95,6 +101,17 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
                 self._act_charge = act
                 break
 
+        # Some MIoT vacuums expose a room map and room-sweep actions.  Detect
+        # that capability from the spec instead of maintaining a model list.
+        self._prop_room_information = miot_service.get_property('room_information')
+        self._act_get_room_configs = miot_service.get_action('get_room_configs')
+        self._act_set_room_clean_configs = miot_service.get_action(
+            'set_room_clean_configs'
+        )
+        self._act_start_room_sweep = miot_service.get_action(
+            'start_vacuum_room_sweep', 'start_room_sweep'
+        )
+
         if self._prop_power:
             self._supported_features |= VacuumEntityFeature.TURN_ON
             self._supported_features |= VacuumEntityFeature.TURN_OFF
@@ -113,6 +130,9 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
             self._supported_features |= VacuumEntityFeature.STATE
         if self._act_locate:
             self._supported_features |= VacuumEntityFeature.LOCATE
+        if (self._prop_room_information and self._act_get_room_configs
+                and self._act_start_room_sweep):
+            self._supported_features |= VacuumEntityFeature.CLEAN_AREA
         self._supported_features |= VacuumEntityFeature.SEND_COMMAND
 
     async def async_update(self):
@@ -212,6 +232,96 @@ class MiotVacuumEntity(MiotEntity, StateVacuumEntity):
         """
         return await self.async_miio_command(command, params)
 
+    async def async_get_segments(self) -> list[Segment]:
+        """Fetch room segments when supported by the MIoT device spec."""
+        if not (self._prop_room_information and self._act_get_room_configs
+                and self._act_start_room_sweep):
+            return []
+        in_properties = self._act_get_room_configs.in_properties()
+        params = self._act_get_room_configs.in_params_from_attrs(
+            {in_properties[0].full_name: ''}
+        ) if in_properties else []
+        await self.async_call_action(
+            self._act_get_room_configs, params, force_params=True
+        )
+        props = await self.device.async_get_properties(
+            [{'siid': self._prop_room_information.service.iid,
+              'piid': self._prop_room_information.iid}],
+            update_entity=True,
+            throw=True,
+        )
+        value = props.get(self._prop_room_information.full_name)
+        segments = _parse_room_information(value)
+        self._state_attrs['room_mapping'] = [
+            [segment.id, segment.id, segment.name] for segment in segments
+        ]
+        return segments
+
+    async def async_clean_segments(self, segment_ids: list[str], **kwargs):
+        """Clean the rooms selected by Home Assistant's area mapping."""
+        if not segment_ids or not self._act_start_room_sweep:
+            return False
+
+        # D102GL-family vacuums require the room-cleaning configuration to be
+        # written before the room-sweep action is accepted.  Other MIoT
+        # vacuums expose only the start action, so retain the direct fallback.
+        if self._act_set_room_clean_configs:
+            config = _room_clean_config(segment_ids)
+            params = self._act_set_room_clean_configs.in_params([config])
+            await self.async_call_action(
+                self._act_set_room_clean_configs, params, force_params=True
+            )
+
+        payload = _room_sweep_payload(segment_ids)
+        params = self._act_start_room_sweep.in_params([payload])
+        return await self.async_call_action(
+            self._act_start_room_sweep, params, force_params=True
+        )
+
+
+def _parse_room_information(value):
+    """Convert a MIoT room-information property into HA segments."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(value, dict):
+        return []
+    rooms = value.get('rooms')
+    if not isinstance(rooms, list):
+        return []
+    segments = []
+    for room in rooms:
+        if not isinstance(room, dict) or room.get('id') is None:
+            continue
+        name = room.get('name') or str(room['id'])
+        segments.append(Segment(id=str(room['id']), name=str(name)))
+    return segments
+
+
+def _room_sweep_payload(segment_ids):
+    """Build the MIoT room-selection argument."""
+    return ','.join(str(segment_id) for segment_id in segment_ids)
+
+
+def _room_clean_config(segment_ids):
+    """Build the room-cleaning configuration used by D102GL-like vacuums."""
+    rooms = []
+    for segment_id in segment_ids:
+        try:
+            rooms.append(int(segment_id))
+        except (TypeError, ValueError):
+            rooms.append(str(segment_id))
+    return json.dumps({
+        'rooms': rooms,
+        # Start with vacuum-only cleaning.  This is the safe default for
+        # room cleaning and matches the D102GL mode accepted while docked.
+        'clean_mode': 1,
+        'is_ai_cleaning': False,
+    }, separators=(',', ':'))
 
 class MiotRoborockVacuumEntity(MiotVacuumEntity):
     def __init__(self, config: dict, miot_service: MiotService):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1,0 +1,34 @@
+from homeassistant.components.vacuum import Segment
+
+from custom_components.xiaomi_miot.vacuum import (
+    _parse_room_information,
+    _room_clean_config,
+    _room_sweep_payload,
+)
+
+
+def test_parse_room_information():
+    result = _parse_room_information(
+        '{"rooms":[{"id":3,"name":"Living Room"},{"id":16,"name":"Office"}],"map_uid":10}'
+    )
+
+    assert result == [
+        Segment(id='3', name='Living Room'),
+        Segment(id='16', name='Office'),
+    ]
+
+
+def test_parse_room_information_rejects_invalid_values():
+    assert _parse_room_information('') == []
+    assert _parse_room_information('{"rooms":null}') == []
+    assert _parse_room_information('not-json') == []
+
+
+def test_room_sweep_payload():
+    assert _room_sweep_payload(['3', '16']) == '3,16'
+
+
+def test_room_clean_config():
+    assert _room_clean_config(['3', '16']) == (
+        '{"rooms":[3,16],"clean_mode":1,"is_ai_cleaning":false}'
+    )


### PR DESCRIPTION
## Summary

Adds discovery of existing named rooms and room-targeted cleaning to MIoT vacuum entities that expose the required device capabilities. Home Assistant can associate these segments with its areas and use `vacuum.clean_area` to clean the selected rooms.

## Behavior

- Detects support from `room_information`, `get_room_configs`, and `start_vacuum_room_sweep` / `start_room_sweep`, without a model-specific branch in platform setup.
- Exposes `CLEAN_AREA` when both the device and Home Assistant support vacuum segments. Older supported Home Assistant versions continue to load the vacuum platform without this feature.
- Refreshes and parses the device's existing room IDs and names through `async_get_segments`, used by Home Assistant's `vacuum/get_segments` WebSocket command, and publishes a `room_mapping` state attribute.
- Routes selected segment IDs to the room-sweep action. When `set_room_clean_configs` is available, first sends the selected rooms with `clean_mode: 1` (vacuum-only) and `is_ai_cleaning: false`; otherwise sends the room-sweep action directly.
- Reports room-refresh, configuration, and start-action failures to Home Assistant. A failed configuration action prevents the subsequent cleaning command.
- Generates vacuum entity IDs in the `vacuum` domain, including when the entity registry is recreated after removing another vacuum integration.

This uses rooms already defined on the device. It does not add map creation, room renaming, boundary editing, or a go-to-room command without cleaning. Capability detection does not establish that every device exposing these action names accepts the same payload format.

## Validation

- Full local test suite: **206 passed** with Home Assistant **2026.9.2**; **203 passed, 3 skipped** with the minimum supported version, **2025.6.0**. The skipped tests require Home Assistant's vacuum segment API.
- Tests cover feature detection, room parsing, payload generation, command order, the path without a configuration action, empty selections, room discovery, and action failures.
- `git diff --check` passes.
- The stable pytest CI job uses Python 3.14 so it can install current Home Assistant releases; the minimum-version job retains Python 3.13. All seven GitHub checks passed for commit `198ae344`.

Previous hardware validation with a Xiaomi X20 Pro (`xiaomi.vacuum.d102gl`) in local/LAN mode on Home Assistant **2026.7.4** confirmed that `CLEAN_AREA` was exposed and `vacuum/get_segments` returned all 10 rooms. That validation predates the current revision. No real cleaning run has been validated; end-to-end cleaning, cloud mode, and additional models still need device testing.
