### PR TITLE
Adds support for xiaomi.fan.p90 (Mijia Smart DC Inverter Circulation Fan Pro)

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -2328,6 +2328,16 @@ DEVICE_CUSTOMIZES = {
             }
         ],
     },
+    'xiaomi.fan.p90': {
+        'sensor_properties': 'fault,delay_remain_time',
+        'switch_properties': 'horizontal_swing,vertical_swing,symmetrical_swing_h,symmetrical_swing_v,'
+                             'alarm,screen.on,physical_controls_locked,off_to_center,delay',
+        'number_properties': 'left_angle,right_angle,up_angle,down_angle,delay_time',
+        'button_actions': 'loop_mode,loop_gear',
+        'configuration_entities': 'symmetrical_swing_*,*_angle,alarm,screen.on,'
+                                  'physical_controls_locked,off_to_center,delay,delay_time',
+        'diagnostic_entities': 'fault,delay_remain_time',
+    },
     'xiaomi.feeder.iv2001': {
         'button_actions': 'pet_food_out,reset_desiccant_life,weigh_manual_calibrate',
         'binary_sensor_properties': 'battery_level',


### PR DESCRIPTION
MIoT spec link: https://home.miot-spec.com/spec/xiaomi.fan.p90

Adds entity customizations for the Mijia Smart DC Inverter Circulation Fan Pro (米家智能变频循环扇Pro).

Notes on the spec:

- Fan speed is a stepless `fan-level` range (1~100) in the `fan` service, so the fan entity picks it up as a percentage without a converter. Unlike `p85`, the duplicate `dm-service.fan-level` is a mirror and is left unexposed.
- Instead of the usual `horizontal-swing-included-angle`, this model exposes independent `left-angle` / `right-angle` / `up-angle` / `down-angle` under `dm-service`, plus `symmetrical-swing-h` / `symmetrical-swing-v`.
- `vertical-swing` is absorbed by `MiotFanConv` but unused (only the first swing property becomes `oscillate`), so both swing switches are exposed explicitly.

Tested on my own Home Assistant instance (HA 2026.8.0 Container) with the device connected through the Xiaomi cloud.