### PR TITLE
🧹 fix status value list for ijai.vacuum models

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1106,6 +1106,7 @@ DEVICE_CUSTOMIZES = {
     },
     'ijai.vacuum.*': {
         'interval_seconds': 120,
+        'extend_miot_specs': 'ijai.vacuum.v10',
         'button_actions': 'start_sweep*,start_only_sweep,start_mop,start_charge,stop_*',
         'sensor_properties': 'vacuum.status,door_state,main_brush_life,side_brush_life,hypa_life,mop_life',
         'switch_properties': 'repeat_state,alarm',

--- a/custom_components/xiaomi_miot/core/miot_specs_extend.json
+++ b/custom_components/xiaomi_miot/core/miot_specs_extend.json
@@ -405,6 +405,31 @@
     }
   ],
 
+  "ijai.vacuum.v10": [
+    {
+      "iid": 2,
+      "properties": [
+        {
+          "iid": 1,
+          "value-list": [
+            {"value": 0, "description": "Sleep"},
+            {"value": 1, "description": "Idle"},
+            {"value": 2, "description": "Paused"},
+            {"value": 3, "description": "Go Charging"},
+            {"value": 4, "description": "Charging"},
+            {"value": 5, "description": "Sweeping"},
+            {"value": 6, "description": "Sweeping And Mopping"},
+            {"value": 7, "description": "Mopping"},
+            {"value": 8, "description": "Upgrading"}
+          ]
+        }
+      ]
+    }
+  ],
+  "ijai.vacuum.v1": "ijai.vacuum.v10",
+  "ijai.vacuum.v2": "ijai.vacuum.v10",
+  "ijai.vacuum.v3": "ijai.vacuum.v10",
+
   "lumi.airer.acn01": [
     {
       "iid": 2,


### PR DESCRIPTION
## Description

This PR fixes an issue where Xiaomi vacuum cleaners under the `ijai.vacuum.*` series (such as `ijai.vacuum.v10` / Vacuum-Mop 2 Lite / S10 / 3C) report state `docked` while actively sweeping/cleaning.

### Root Cause
In the Xiaomi Cloud MIoT specification for `urn:miot-spec-v2:device:vacuum:0000A006:ijai-v10:1`, value `5` was mistakenly registered with description `"Charging"` instead of `"Sweeping"` in the base English schema (and `2` as `"Sweeping"` instead of `"Paused"`).

Because `MiotVacuumEntity` maps activity using `self._prop_status.list_search('Charging', ...)`, whenever the vacuum sweeps (`vacuum.status = 5`), `5` matched `'Charging'` and set the activity to `VacuumActivity.DOCKED`.

The actual firmware mapping for `ijai.vacuum` models is:
- **`0`**: `Sleep`
- **`1`**: `Idle`
- **`2`**: `Paused`
- **`3`**: `Go Charging`
- **`4`**: `Charging`
- **`5`**: `Sweeping`
- **`6`**: `Sweeping And Mopping`
- **`7`**: `Mopping`
- **`8`**: `Upgrading`

### Solution
1. Add spec extension for `ijai.vacuum.v10` (and aliases) in `miot_specs_extend.json` with the corrected `value-list` for property `status` (`siid: 2, piid: 1`).
2. Point `extend_miot_specs` to `ijai.vacuum.v10` in `device_customizes.py` for `ijai.vacuum.*`.
