### PR TITLE
feat: expose full motion video list for dual-lens devices

### DIFF
--- a/custom_components/xiaomi_miot/camera.py
+++ b/custom_components/xiaomi_miot/camera.py
@@ -233,7 +233,8 @@ class BaseCameraEntity(Camera):
                 'motion_video_time': f'{datetime.fromtimestamp(tim)}',
                 'motion_video_type': fst.get('eventType'),
                 'motion_video_latest': fst,
-                # 通用：暴露完整事件列表（含双镜头），供自动化自行配对
+                # Expose the full event list so dual-lens devices (e.g. M30 Pro
+                # door lock) can access both streams and pair them by createTime.
                 'motion_video_list': [dict(u) for u in rls],
             }
         else:

--- a/custom_components/xiaomi_miot/camera.py
+++ b/custom_components/xiaomi_miot/camera.py
@@ -227,12 +227,14 @@ class BaseCameraEntity(Camera):
         rls = rdt.get('data', {}).get('thirdPartPlayUnits') or []
         adt = {}
         if rls:
-            fst = rls[0] or {}
+            fst = dict(rls[0] or {})
             tim = fst.pop('createTime', 0) / 1000
             adt = {
                 'motion_video_time': f'{datetime.fromtimestamp(tim)}',
                 'motion_video_type': fst.get('eventType'),
                 'motion_video_latest': fst,
+                # 通用：暴露完整事件列表（含双镜头），供自动化自行配对
+                'motion_video_list': [dict(u) for u in rls],
             }
         else:
             self.log.info('Camera events is empty. %s', rdt)


### PR DESCRIPTION
Expose the full list of thirdPartPlayUnits as a new attribute motion_video_list in get_alarm_eventlist(), so devices with dual-lens cameras (e.g. M30 Pro door lock) can access both streams.

Backward compatible: motion_video_latest is unchanged.

Fixes #2929 