### PR TITLE
Fix missing MAC address in connection data

### DIFF
--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -297,12 +297,24 @@ class Device(CustomConfigHelper):
         return {(DOMAIN, self.unique_id)}
 
     @property
+    def connections(self):
+        connections = set()
+
+        if mac := self.info.mac:
+            connections.add(
+                (dr.CONNECTION_NETWORK_MAC, mac)
+            )
+
+        return connections
+
+    @property
     def hass_device_info(self):
         via_device = None
         if self._proxy_device:
             via_device = next(iter(self._proxy_device.identifiers))
         return {
             'identifiers': self.identifiers,
+            'connections': self.connections,
             'name': self.name,
             'model': self.model,
             'manufacturer': (self.model or 'Xiaomi').split('.', 1)[0],


### PR DESCRIPTION
fix #2932 

Make the device's connection information available so that Home Assistant can link physical devices across different integrations.
