### PR TITLE
Fix device registry compatibility with Home Assistant 2026.9

### DIFF
--- a/custom_components/xiaomi_miot/core/device.py
+++ b/custom_components/xiaomi_miot/core/device.py
@@ -298,19 +298,23 @@ class Device(CustomConfigHelper):
 
     @property
     def hass_device_info(self):
-        via_device = None
-        if self._proxy_device:
-            via_device = next(iter(self._proxy_device.identifiers))
-        return {
+        device_info = {
             'identifiers': self.identifiers,
             'name': self.name,
             'model': self.model,
             'manufacturer': (self.model or 'Xiaomi').split('.', 1)[0],
             'sw_version': self.sw_version,
             'suggested_area': self.info.room_name,
-            'via_device': via_device,
             'configuration_url': f'https://home.miot-spec.com/s/{self.model}',
         }
+        if self._proxy_device:
+            dev_reg = dr.async_get(self.hass)
+            if hasattr(dev_reg, 'async_get_device_by_identifier'):
+                if parent := self._proxy_device.hass_device:
+                    device_info['via_device_id'] = parent.id
+            else:
+                device_info['via_device'] = next(iter(self._proxy_device.identifiers))
+        return device_info
 
     @property
     def customizes(self):
@@ -365,6 +369,10 @@ class Device(CustomConfigHelper):
     @property
     def hass_device(self):
         dev_reg = dr.async_get(self.hass)
+        if hasattr(dev_reg, 'async_get_device_by_identifier'):
+            return dev_reg.async_get_device_by_identifier(
+                next(iter(self.identifiers)), self.entry.id
+            )
         return dev_reg.async_get_device(self.identifiers)
 
     @property
@@ -946,7 +954,7 @@ class Device(CustomConfigHelper):
 
         if self.miot_results.updater != self.data.get('updater'):
             dev_reg = dr.async_get(self.hass)
-            if dev := dev_reg.async_get_device(self.identifiers):
+            if dev := self.hass_device:
                 self.data['updater'] = self.miot_results.updater
                 dev_reg.async_update_device(dev.id, sw_version=self.sw_version)
                 self.log.info('State updater: %s', self.sw_version)

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -1,0 +1,85 @@
+"""Tests for Xiaomi MIoT device registry compatibility."""
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from custom_components.xiaomi_miot.core.device import Device, DeviceInfo
+
+
+def _make_device(hass, *, unique_id, entry_id="test-entry"):
+    entry = SimpleNamespace(
+        hass=hass,
+        cloud=None,
+        id=entry_id,
+        get_config=lambda key=None, default=None: default,
+    )
+    info = DeviceInfo({
+        "did": unique_id,
+        "mac": unique_id,
+        "name": "Test Device",
+        "model": "test.device.model",
+    })
+    return Device(info, entry)
+
+
+def test_device_info_omits_empty_via_device(hass):
+    """Do not pass the deprecated via_device key for standalone devices."""
+    device = _make_device(hass, unique_id="aa:bb:cc:dd:ee:01")
+
+    assert "via_device" not in device.hass_device_info
+    assert "via_device_id" not in device.hass_device_info
+
+
+def test_device_info_uses_parent_device_id(hass):
+    """Link proxy devices using the parent's registry ID on newer HA versions."""
+    parent = _make_device(hass, unique_id="aa:bb:cc:dd:ee:01")
+    child = _make_device(hass, unique_id="aa:bb:cc:dd:ee:02")
+    child._proxy_device = parent
+    parent_entry = SimpleNamespace(id="parent-device-id")
+    registry = Mock()
+    registry.async_get_device_by_identifier.return_value = parent_entry
+
+    with patch(
+        "custom_components.xiaomi_miot.core.device.dr.async_get",
+        return_value=registry,
+    ):
+        device_info = child.hass_device_info
+
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        next(iter(parent.identifiers)), parent.entry.id
+    )
+    assert device_info["via_device_id"] == parent_entry.id
+    assert "via_device" not in device_info
+
+
+def test_hass_device_uses_unambiguous_identifier_lookup(hass):
+    """Look up devices within their owning config entry on newer HA versions."""
+    device = _make_device(hass, unique_id="aa:bb:cc:dd:ee:01")
+    registry = Mock()
+    registry.async_get_device_by_identifier.return_value = expected = object()
+
+    with patch(
+        "custom_components.xiaomi_miot.core.device.dr.async_get",
+        return_value=registry,
+    ):
+        assert device.hass_device is expected
+
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        next(iter(device.identifiers)), device.entry.id
+    )
+
+
+def test_device_info_falls_back_to_parent_identifier(hass):
+    """Keep proxy device links working on HA versions before 2026.8."""
+    parent = _make_device(hass, unique_id="aa:bb:cc:dd:ee:01")
+    child = _make_device(hass, unique_id="aa:bb:cc:dd:ee:02")
+    child._proxy_device = parent
+    registry = SimpleNamespace(async_get_device=Mock())
+
+    with patch(
+        "custom_components.xiaomi_miot.core.device.dr.async_get",
+        return_value=registry,
+    ):
+        device_info = child.hass_device_info
+
+    assert device_info["via_device"] == next(iter(parent.identifiers))
+    assert "via_device_id" not in device_info


### PR DESCRIPTION
## Summary

- stop including the deprecated `via_device` field for standalone MIoT devices
- link proxy devices with the parent registry entry's `via_device_id` on newer Home Assistant versions
- replace ambiguous `async_get_device` calls with config-entry-scoped `async_get_device_by_identifier` lookups when available
- retain the legacy identifier-based behavior for the minimum supported Home Assistant version
- add focused coverage for standalone devices, proxy-device links, scoped lookups, and the legacy fallback

Fixes #2937.

## Problem

Home Assistant 2026.9 reports the deprecated `DeviceInfo.via_device` field through its frame helper. Xiaomi Miot currently includes that field for every device, including standalone devices where its value is `None`.

For entities added dynamically outside the original integration setup frame, this is not limited to a warning. Device registration can fail with:

```text
Error adding entity ... for domain vacuum with platform xiaomi_miot
RuntimeError: Detected code that calls `device_registry.async_get_or_create`
with a deprecated `via_device` parameter; use `via_device_id` instead.
```

The config entry can remain loaded and auxiliary sensors/buttons can continue updating, while the primary entity is never registered and remains unavailable. The same code path also uses the deprecated, ambiguous `async_get_device(identifiers)` lookup in two places.

## Root cause

`Device.hass_device_info` always returned a `via_device` key. Home Assistant 2026.8 introduced config-entry-scoped device lookups and `via_device_id`; Home Assistant 2026.9 removed `via_device` from `DeviceInfo` and reports its use as deprecated.

A direct rename is insufficient because `via_device` contains an identifier tuple while `via_device_id` requires the actual parent `DeviceEntry.id`.

## Change

On Home Assistant versions exposing `async_get_device_by_identifier`, the integration now:

1. resolves devices by their identifier and owning config entry;
2. resolves a proxy's parent `DeviceEntry` and supplies its registry ID as `via_device_id`;
3. omits both relationship fields for standalone devices.

On older supported versions, feature detection preserves the existing `via_device` identifier behavior for proxy devices.

## Validation

- [x] Full test suite with Home Assistant 2026.9.0 / Python 3.14: `174 passed`
- [x] Full minimum-version suite with Home Assistant 2025.6.0 / Python 3.13: `174 passed`
- [x] `git diff --check`
- [x] Live Home Assistant OS 2026.9.0 smoke test with a Xiaomi D102GL vacuum
  - before: the `vacuum` entity failed registration with the `via_device` `RuntimeError`, while auxiliary telemetry continued updating
  - after: the config entry loaded, the primary `vacuum` entity was recreated as `docked`, status/battery/fan-speed telemetry updated, and the `via_device` / `async_get_device` warnings addressed by this change no longer appeared after restart
